### PR TITLE
Add InfiniBand perf test with CUDA support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+FROM salanki/rdma-perftest:11.4 AS perftest
 FROM nvidia/cuda:11.6.2-devel-ubuntu20.04
 
 ARG DEBIAN_FRONTEND=noninteractive
@@ -85,6 +86,16 @@ ENV OLD_CPATH=
 ENV CPATH=/hpcx/ompi/include:/hpcx/ucc/include:/hpcx/ucx/include:/hpcx/sharp/include:/hpcx/hcoll/include:
 ENV PKG_CONFIG_PATH=/hpcx/hcoll/lib/pkgconfig:/hpcx/sharp/lib/pkgconfig:/hpcx/ucx/lib/pkgconfig:/hpcx/ompi/lib/pkgconfig:
 # End of auto-generated paths
+
+# Copy in perftest with GPU support
+COPY --from=perftest /usr/bin/ib_atomic_bw /usr/bin/ib_atomic_bw
+COPY --from=perftest /usr/bin/ib_atomic_lat /usr/bin/ib_atomic_lat
+COPY --from=perftest /usr/bin/ib_read_bw /usr/bin/ib_read_bw
+COPY --from=perftest /usr/bin/ib_read_lat /usr/bin/ib_read_lat
+COPY --from=perftest /usr/bin/ib_send_bw /usr/bin/ib_send_bw
+COPY --from=perftest /usr/bin/ib_send_lat /usr/bin/ib_send_lat
+COPY --from=perftest /usr/bin/ib_write_bw /usr/bin/ib_write_bw
+COPY --from=perftest /usr/bin/ib_write_lat /usr/bin/ib_write_lat
 
 # NCCL Tests
 ENV NCCL_TESTS_COMMITISH=8274cb4

--- a/nccl-test-distributed-128-las1-mpijob.yaml
+++ b/nccl-test-distributed-128-las1-mpijob.yaml
@@ -75,7 +75,7 @@ spec:
                     operator: In
                     values:
                     - A100_NVLINK_80GB
-                  - key: failure-domain.beta.kubernetes.io/region
+                  - key: topology.kubernetes.io/region
                     operator: In
                     values:
                     - LAS1
@@ -84,11 +84,5 @@ spec:
             - emptyDir:
                 medium: Memory
               name: dshm
-
-          tolerations:
-          - effect: NoSchedule
-            key: node.coreweave.cloud/reserved-for
-            operator: Equal
-            value: tenant-eleutherai
           enableServiceLinks: false
           automountServiceAccountToken: false

--- a/nccl-test-distributed-64-gdrcopy-las1-mpijob.yaml
+++ b/nccl-test-distributed-64-gdrcopy-las1-mpijob.yaml
@@ -93,10 +93,5 @@ spec:
             - name: gdrdrv
               hostPath:
                 path: /dev/gdrdrv
-          tolerations:
-          - effect: NoSchedule
-            key: node.coreweave.cloud/reserved-for
-            operator: Equal
-            value: tenant-eleutherai
           enableServiceLinks: false
           automountServiceAccountToken: false

--- a/nccl-test-distributed-64-las1-mpijob.yaml
+++ b/nccl-test-distributed-64-las1-mpijob.yaml
@@ -41,7 +41,7 @@ spec:
                 requiredDuringSchedulingIgnoredDuringExecution:
                   nodeSelectorTerms:
                     - matchExpressions:
-                      - key: failure-domain.beta.kubernetes.io/region
+                      - key: topology.kubernetes.io/region
                         operator: In
                         values:
                         - LAS1

--- a/nccl-test-distributed-a40-64-las1-mpijob.yaml
+++ b/nccl-test-distributed-a40-64-las1-mpijob.yaml
@@ -75,7 +75,7 @@ spec:
                     operator: In
                     values:
                     - A40
-                  - key: failure-domain.beta.kubernetes.io/region
+                  - key: topology.kubernetes.io/region
                     operator: In
                     values:
                     - LAS1
@@ -84,11 +84,5 @@ spec:
             - emptyDir:
                 medium: Memory
               name: dshm
-
-          tolerations:
-          - effect: NoSchedule
-            key: node.coreweave.cloud/reserved-for
-            operator: Equal
-            value: tenant-eleutherai
           enableServiceLinks: false
           automountServiceAccountToken: false


### PR DESCRIPTION
Includes InfiniBand performance test suite built with support for GPUDirect. It might not be necessary in this image, we might want to leave it out to keep the Dockerfile cleaner. Not sure yet.
