### PR TITLE
Upgrade dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,11 +19,11 @@ RUN cd /etc/apt/sources.list.d/ && wget https://linux.mellanox.com/public/repo/m
         openssh-server \
     && rm -rf /var/lib/apt/lists/*
 
-# HPC-X (2.11)
-ENV HPCX_VERSION=2.11
+# HPC-X (2.12)
+ENV HPCX_VERSION=2.12
 RUN cd /tmp && \
-    wget -q -O - http://blobstore.s3.ord1.coreweave.com/drivers/hpcx-v${HPCX_VERSION}-gcc-MLNX_OFED_LINUX-5-ubuntu20.04-cuda11-gdrcopy2-nccl2.11-x86_64.tbz | tar xjf - && \
-    mv hpcx-v${HPCX_VERSION}-gcc-MLNX_OFED_LINUX-5-ubuntu20.04-cuda11-gdrcopy2-nccl2.11-x86_64 /hpcx
+    wget -q -O - http://blobstore.s3.ord1.coreweave.com/drivers/hpcx-v${HPCX_VERSION}-gcc-MLNX_OFED_LINUX-5-ubuntu20.04-cuda11-gdrcopy2-nccl${HPCX_VERSION}-x86_64.tbz | tar xjf - && \
+    mv hpcx-v${HPCX_VERSION}-gcc-MLNX_OFED_LINUX-5-ubuntu20.04-cuda11-gdrcopy2-nccl${HPCX_VERSION}-x86_64 /hpcx
 
 # GDRCopy userspace components (2.3)
 RUN cd /tmp && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -87,7 +87,7 @@ ENV PKG_CONFIG_PATH=/hpcx/hcoll/lib/pkgconfig:/hpcx/sharp/lib/pkgconfig:/hpcx/uc
 # End of auto-generated paths
 
 # NCCL Tests
-ENV NCCL_TESTS_COMMITISH=8274cb4
+ENV NCCL_TESTS_COMMITISH=d313d20
 WORKDIR /opt/nccl_tests
 RUN  wget -q -O - https://github.com/NVIDIA/nccl-tests/archive/${NCCL_TESTS_COMMITISH}.tar.gz | tar --strip-components=1 -xzf - \
    && make MPI=1


### PR DESCRIPTION
- Upgrade HPC-X to 2.12
- Upgrade nccl-tests to d313d20

SHARP is built from master so that will be upgrade as well. Need to change to pin it to a commit. Staying on CUDA 11.6