### PR TITLE
Fix CUDA 12.0.1 image tag in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ CoreWeave also [publishes images](https://hub.docker.com/r/coreweave/nccl-tests/
 
 | **Image Tag** | **CUDA** | **NCCL** | **HPC-X** |
 |---------------|----------|----------|-----------|
-| ghcr.io/coreweave/nccl-tests:12.0.1-devel-ubuntu20.04-nccl2.16.5-1-8fc1a44 | 12.0.1   | 2.17.1   | 2.14.0    |
+| ghcr.io/coreweave/nccl-tests:12.0.1-devel-ubuntu20.04-nccl2.17.1-1-8fc1a44 | 12.0.1   | 2.17.1   | 2.14.0    |
 | ghcr.io/coreweave/nccl-tests:11.8.0-devel-ubuntu20.04-nccl2.16.2-1-4a46534 | 11.8.0   | 2.16.2   | 2.14.0    |
 | ghcr.io/coreweave/nccl-tests:11.7.1-devel-ubuntu20.04-nccl2.14.3-1-4a46534 | 11.7.1   | 2.14.3   | 2.14.0    |
 | coreweave/nccl-tests:2022-09-28_16-34-19.392_EDT            | 11.6.2   | 2.12.0   | 2.12      |


### PR DESCRIPTION
Small typo fix: `12.0.1-devel-ubuntu20.04-nccl2.16.5-1-8fc1a44` (doesn't exist) → [`12.0.1-devel-ubuntu20.04-nccl2.17.1-1-8fc1a44`](https://github.com/coreweave/nccl-tests/pkgs/container/nccl-tests/74352388?tag=12.0.1-devel-ubuntu20.04-nccl2.17.1-1-8fc1a44).