### PR TITLE
Fix invalid ENV definition when setting UCX_VFS_ENABLE=no

### DIFF
--- a/Dockerfile.ubuntu20
+++ b/Dockerfile.ubuntu20
@@ -110,7 +110,7 @@ ENV PKG_CONFIG_PATH=/opt/hpcx/hcoll/lib/pkgconfig:/opt/hpcx/sharp/lib/pkgconfig:
 # End of auto-generated paths
 
 # Disable UCX VFS to stop errors about fuse mount failure
-ENV export UCX_VFS_ENABLE=no
+ENV UCX_VFS_ENABLE=no
 
 # Rebuild OpenMPI to support SLURM
 # For Ubuntu 22, we can replace PMI2 (--with-pmi) with PMIx

--- a/Dockerfile.ubuntu22
+++ b/Dockerfile.ubuntu22
@@ -110,7 +110,7 @@ ENV PKG_CONFIG_PATH=/opt/hpcx/hcoll/lib/pkgconfig:/opt/hpcx/sharp/lib/pkgconfig:
 # End of auto-generated paths
 
 # Disable UCX VFS to stop errors about fuse mount failure
-ENV export UCX_VFS_ENABLE=no
+ENV UCX_VFS_ENABLE=no
 
 # Rebuild OpenMPI to support SLURM
 RUN cd /opt/hpcx/sources/ && rm -r /opt/hpcx/ompi && tar -zxvf openmpi-gitclone.tar.gz && cd openmpi-gitclone && \


### PR DESCRIPTION
Fix for syntax in the line `ENV export UCX_VFS_ENABLE=no` added in commit 3e2155e. It was setting the variable `$export` to the value `"UCX_VFS_ENABLE=no"` rather than `$UCX_VFS_ENABLE` to `"no"`.

&ofcir; I only noticed this while looking through all environment variables via `export -p`. It wasn't causing issues for me. I cannot tell whether the line truly even still needs to be there, since it was doing nothing until now.

So in case it may help, here is a fix to what it was originally intended to do.