### PR TITLE
Fix HPC-X library path prefixes

### DIFF
--- a/Dockerfile.ubuntu20
+++ b/Dockerfile.ubuntu20
@@ -53,11 +53,15 @@ RUN mkdir /tmp/build && \
     rm -r /tmp/build
 
 # HPC-X (2.14.0)
+# grep + sed is used as a workaround to update hardcoded pkg-config / libtools archive / CMake prefixes
 ENV HPCX_VERSION=2.14
 ENV HPCX_NCCL_VERSION=2.16
 RUN cd /tmp && \
-    wget -q -O - http://blobstore.s3.ord1.coreweave.com/drivers/hpcx-v${HPCX_VERSION}-gcc-MLNX_OFED_LINUX-5-ubuntu20.04-cuda11-gdrcopy2-nccl${HPCX_NCCL_VERSION}-x86_64.tbz | tar xjf - && \
-    mv hpcx-v${HPCX_VERSION}-gcc-MLNX_OFED_LINUX-5-ubuntu20.04-cuda11-gdrcopy2-nccl${HPCX_NCCL_VERSION}-x86_64 /opt/hpcx
+    export HPCX_DISTRIBUTION="hpcx-v${HPCX_VERSION}-gcc-MLNX_OFED_LINUX-5-ubuntu20.04-cuda11-gdrcopy2-nccl${HPCX_NCCL_VERSION}-x86_64" \
+           HPCX_DIR="/opt/hpcx" && \
+    wget -q -O - http://blobstore.s3.ord1.coreweave.com/drivers/${HPCX_DISTRIBUTION}.tbz | tar xjf - && \
+    grep -IrlF "/build-result/${HPCX_DISTRIBUTION}" ${HPCX_DISTRIBUTION} | xargs sed -i -e "s:/build-result/${HPCX_DISTRIBUTION}:${HPCX_DIR}:g" && \
+    mv ${HPCX_DISTRIBUTION} ${HPCX_DIR}
 
 # GDRCopy userspace components (2.3)
 RUN cd /tmp && \

--- a/Dockerfile.ubuntu22
+++ b/Dockerfile.ubuntu22
@@ -53,11 +53,15 @@ RUN mkdir /tmp/build && \
     rm -r /tmp/build
 
 # HPC-X (2.13.1)
+# grep + sed is used as a workaround to update hardcoded pkg-config / libtools archive / CMake prefixes
 ENV HPCX_VERSION=2.13.1
 ENV HPCX_NCCL_VERSION=2.12
 RUN cd /tmp && \
-    wget -q -O - http://blobstore.s3.ord1.coreweave.com/drivers/hpcx-v${HPCX_VERSION}-gcc-MLNX_OFED_LINUX-5-ubuntu20.04-cuda11-gdrcopy2-nccl${HPCX_NCCL_VERSION}-x86_64.tbz | tar xjf - && \
-    mv hpcx-v${HPCX_VERSION}-gcc-MLNX_OFED_LINUX-5-ubuntu20.04-cuda11-gdrcopy2-nccl${HPCX_NCCL_VERSION}-x86_64 /opt/hpcx
+    export HPCX_DISTRIBUTION="hpcx-v${HPCX_VERSION}-gcc-MLNX_OFED_LINUX-5-ubuntu20.04-cuda11-gdrcopy2-nccl${HPCX_NCCL_VERSION}-x86_64" \
+           HPCX_DIR="/opt/hpcx" && \
+    wget -q -O - http://blobstore.s3.ord1.coreweave.com/drivers/${HPCX_DISTRIBUTION}.tbz | tar xjf - && \
+    grep -IrlF "/build-result/${HPCX_DISTRIBUTION}" ${HPCX_DISTRIBUTION} | xargs sed -i -e "s:/build-result/${HPCX_DISTRIBUTION}:${HPCX_DIR}:g" && \
+    mv ${HPCX_DISTRIBUTION} ${HPCX_DIR}
 
 # GDRCopy userspace components (2.3)
 RUN cd /tmp && \


### PR DESCRIPTION
The [HPC-X distribution](https://github.com/coreweave/nccl-tests/blob/0f507b126733ec48074f282baa15890d3791ce1f/Dockerfile.ubuntu20#L59) used contains several `.pc` (pkg-config), `.la` (libtools archive), and `.cmake` configuration files with inaccurate (when used here) hardcoded prefixes for library file locations, making it impossible to link with certain libraries when using tools that read and depend on those configurations.

For example, trying to link against UCX in a CMake build redirects the linker to a nonexistent path due to its `ucx-targets.cmake` file, and then fails, even with a correct `LIBRARY_PATH` environment variable.

This PR adds code to update all detected hardcoded prefixes to the HPC-X path used in this image with a find-and-replace operation during installation.

A list of affected files in the latest published images is:
```
/opt/hpcx/clusterkit/bin/clusterkit.sh
/opt/hpcx/clusterkit/lib/libcuda_wrapper.la
/opt/hpcx/hcoll/debug/lib/pkgconfig/hcoll.pc
/opt/hpcx/hcoll/lib/pkgconfig/hcoll.pc
/opt/hpcx/sharp/debug/lib/pkgconfig/sharp.pc
/opt/hpcx/sharp/debug/sbin/sharp.init
/opt/hpcx/sharp/debug/systemd/system/sharp_am.service
/opt/hpcx/sharp/lib/pkgconfig/sharp.pc
/opt/hpcx/sharp/sbin/sharp.init
/opt/hpcx/sharp/systemd/system/sharp_am.service
/opt/hpcx/ucx/debug/lib/cmake/ucx/ucx-targets.cmake
/opt/hpcx/ucx/debug/lib/pkgconfig/ucx-cma.pc
/opt/hpcx/ucx/debug/lib/pkgconfig/ucx-fuse.pc
/opt/hpcx/ucx/debug/lib/pkgconfig/ucx-ib.pc
/opt/hpcx/ucx/debug/lib/pkgconfig/ucx-rdmacm.pc
/opt/hpcx/ucx/debug/lib/pkgconfig/ucx-ucs.pc
/opt/hpcx/ucx/debug/lib/pkgconfig/ucx-uct.pc
/opt/hpcx/ucx/debug/lib/pkgconfig/ucx-xpmem.pc
/opt/hpcx/ucx/debug/lib/pkgconfig/ucx.pc
/opt/hpcx/ucx/lib/cmake/ucx/ucx-targets.cmake
/opt/hpcx/ucx/lib/pkgconfig/ucx-cma.pc
/opt/hpcx/ucx/lib/pkgconfig/ucx-fuse.pc
/opt/hpcx/ucx/lib/pkgconfig/ucx-ib.pc
/opt/hpcx/ucx/lib/pkgconfig/ucx-rdmacm.pc
/opt/hpcx/ucx/lib/pkgconfig/ucx-ucs.pc
/opt/hpcx/ucx/lib/pkgconfig/ucx-uct.pc
/opt/hpcx/ucx/lib/pkgconfig/ucx-xpmem.pc
/opt/hpcx/ucx/lib/pkgconfig/ucx.pc
/opt/hpcx/ucx/mt/lib/cmake/ucx/ucx-targets.cmake
/opt/hpcx/ucx/mt/lib/pkgconfig/ucx-cma.pc
/opt/hpcx/ucx/mt/lib/pkgconfig/ucx-fuse.pc
/opt/hpcx/ucx/mt/lib/pkgconfig/ucx-ib.pc
/opt/hpcx/ucx/mt/lib/pkgconfig/ucx-rdmacm.pc
/opt/hpcx/ucx/mt/lib/pkgconfig/ucx-ucs.pc
/opt/hpcx/ucx/mt/lib/pkgconfig/ucx-uct.pc
/opt/hpcx/ucx/mt/lib/pkgconfig/ucx-xpmem.pc
/opt/hpcx/ucx/mt/lib/pkgconfig/ucx.pc
/opt/hpcx/ucx/prof/lib/cmake/ucx/ucx-targets.cmake
/opt/hpcx/ucx/prof/lib/pkgconfig/ucx-cma.pc
/opt/hpcx/ucx/prof/lib/pkgconfig/ucx-fuse.pc
/opt/hpcx/ucx/prof/lib/pkgconfig/ucx-ib.pc
/opt/hpcx/ucx/prof/lib/pkgconfig/ucx-rdmacm.pc
/opt/hpcx/ucx/prof/lib/pkgconfig/ucx-ucs.pc
/opt/hpcx/ucx/prof/lib/pkgconfig/ucx-uct.pc
/opt/hpcx/ucx/prof/lib/pkgconfig/ucx-xpmem.pc
/opt/hpcx/ucx/prof/lib/pkgconfig/ucx.pc
```

Additionally featuring a few other filetypes such as `.sh` and `.init`.

As a concrete example, the broken behaviour of the `ucx-targets.cmake` file mentioned earlier comes from lines like these:

```cmake
# /opt/hpcx/ucx/lib/cmake/ucx/ucx-targets.cmake:

set(prefix "/build-result/hpcx-v2.14-gcc-MLNX_OFED_LINUX-5-ubuntu20.04-cuda11-gdrcopy2-nccl2.16-x86_64/ucx")
set(exec_prefix "${prefix}")

add_library(ucx::ucs SHARED IMPORTED)

set_target_properties(ucx::ucs PROPERTIES
  IMPORTED_LOCATION "${exec_prefix}/lib/libucs.so"
  INTERFACE_INCLUDE_DIRECTORIES "${prefix}/include"
)
```

Which forces the **exact** (nonexistent) path `/build-result/hpcx-v2.14-gcc-MLNX_OFED_LINUX-5-ubuntu20.04-cuda11-gdrcopy2-nccl2.16-x86_64/ucx/lib/libucs.so` to be used by CMake when it tries to link in that library.

This fix adapts code like that to use a valid path, e.g.:

```cmake
set(prefix "/opt/hpcx/ucx")
```