### PR TITLE
Add NCCL v2.18.0-1 builds for CUDA 11.8 & 12.0

### DIFF
--- a/.github/workflows/ubuntu-20.yml
+++ b/.github/workflows/ubuntu-20.yml
@@ -31,6 +31,18 @@ jobs:
       nccl-version: 2.16.2-1
       cuda-samples-version: "11.6"
 
+  cu118-nccl2.18.0:
+    uses: ./.github/workflows/build.yml
+    with:
+      folder: .
+      dockerfile: Dockerfile.ubuntu20
+      base-image: nvidia/cuda
+      base-tag: 11.8.0-cudnn8-devel-ubuntu20.04
+      cuda-version-minor: "11.8.0"
+      cuda-version-major: "11.8"
+      nccl-version: 2.18.0-1
+      cuda-samples-version: "11.6"
+
   cu120:
     uses: ./.github/workflows/build.yml
     with:
@@ -41,4 +53,16 @@ jobs:
       cuda-version-minor: "12.0.1"
       cuda-version-major: "12.0"
       nccl-version: 2.17.1-1
+      cuda-samples-version: "12.0"
+
+  cu120-nccl2.18.0:
+    uses: ./.github/workflows/build.yml
+    with:
+      folder: .
+      dockerfile: Dockerfile.ubuntu20
+      base-image: nvidia/cuda
+      base-tag: 12.0.1-cudnn8-devel-ubuntu20.04
+      cuda-version-minor: "12.0.1"
+      cuda-version-major: "12.0"
+      nccl-version: 2.18.0-1
       cuda-samples-version: "12.0"

--- a/.github/workflows/ubuntu-20.yml
+++ b/.github/workflows/ubuntu-20.yml
@@ -31,7 +31,7 @@ jobs:
       nccl-version: 2.16.2-1
       cuda-samples-version: "11.6"
 
-  cu118-nccl2.18.0:
+  cu118-nccl2_18:
     uses: ./.github/workflows/build.yml
     with:
       folder: .
@@ -55,7 +55,7 @@ jobs:
       nccl-version: 2.17.1-1
       cuda-samples-version: "12.0"
 
-  cu120-nccl2.18.0:
+  cu120-nccl2_18:
     uses: ./.github/workflows/build.yml
     with:
       folder: .

--- a/Dockerfile.ubuntu20
+++ b/Dockerfile.ubuntu20
@@ -14,8 +14,7 @@ RUN apt-get -qq update && \
         iputils-ping net-tools \
         libnuma1 libsubunit0 libpci-dev \
         libpmix-dev \
-        datacenter-gpu-manager \
-        libnccl2=$TARGET_NCCL_VERSION+cuda${CUDA_VERSION_MAJOR} libnccl-dev=${TARGET_NCCL_VERSION}+cuda${CUDA_VERSION_MAJOR}
+        datacenter-gpu-manager
 
 # Mellanox OFED (latest)
 RUN wget -qO - https://www.mellanox.com/downloads/ofed/RPM-GPG-KEY-Mellanox | apt-key add -
@@ -26,6 +25,21 @@ RUN apt-get -qq update \
     ibverbs-utils libibverbs-dev libibumad3 libibumad-dev librdmacm-dev rdmacm-utils infiniband-diags ibverbs-utils \
     && rm -rf /var/lib/apt/lists/*
 #         mlnx-ofed-hpc-user-only
+
+# Install nccl, either through apt, or a build from CoreWeave for special versions.
+RUN mkdir /tmp/nccl-install && \
+    cd /tmp/nccl-install && \
+    { \
+        if [ "${TARGET_NCCL_VERSION}" = "2.18.0-1" ]; then \
+            wget -q -O - http://blobstore.s3.ord1.coreweave.com/drivers/nccl/nccl-v${TARGET_NCCL_VERSION}-cuda${CUDA_VERSION_MAJOR}-ubuntu20.04-x86_64.tbz | tar xjf -; \
+        else \
+            apt-get -qq update && apt-get -qq download \
+              libnccl2=${TARGET_NCCL_VERSION}+cuda${CUDA_VERSION_MAJOR} libnccl-dev=${TARGET_NCCL_VERSION}+cuda${CUDA_VERSION_MAJOR}; \
+        fi; \
+    } && \
+    dpkg -i ./libnccl*.deb && \
+    cd /tmp && \
+    rm -r /tmp/nccl-install
 
 # IB perftest with GDR
 ENV PERFTEST_VERSION=4.5-0.20


### PR DESCRIPTION
This PR adds additional builds with NCCL v2.18.0-1 for both CUDA 11.8 and CUDA 12.0 on Ubuntu 20.04.

- Since this isn't a fully finalized NCCL release, these builds *do not replace* the existing builds with NCCL 2.16.2-1 and 2.17.1-1; there are instead two new additional CI jobs for v2.18.0-1.
- `Dockerfile.ubuntu20` is configured to conditionally download a CoreWeave-hosted NCCL distribution only when targeting NCCL version 2.18.0-1, since it is not yet available for download elsewhere.

Once NCCL v2.18 is officially available, these extra steps may be unnecessary, so this branch may either be merged as-is and changed again later, or simply left as a draft until NCCL v2.18's release, to add it in a more stable state. Either way, containers will be available built from this branch; [`11.8.0-cudnn8-devel-ubuntu20.04-nccl2.18.0-1-cca4d43`](https://github.com/orgs/coreweave/packages/container/nccl-tests/86136626?tag=11.8.0-cudnn8-devel-ubuntu20.04-nccl2.18.0-1-cca4d43) is already finished and available for testing as of writing this.

CC: @rickhard, @salanki