### PR TITLE
fix: Stop disabling LL128 for the H100s

### DIFF
--- a/nccl-test-distributed-h100-64-las1-mpijob.yaml
+++ b/nccl-test-distributed-h100-64-las1-mpijob.yaml
@@ -32,7 +32,7 @@ spec:
                     -x NCCL_IB_PCI_RELAXED_ORDERING=1 \
                     -x SHARP_COLL_ENABLE_PCI_RELAXED_ORDERING=1 \
                     -x NCCL_COLLNET_ENABLE=0 \
-                    -x NCCL_PROTO=^LL128 \
+                    -x NCCL_IB_PCI_RELAXED_ORDERING=0 \
                     /opt/nccl_tests/build/all_reduce_perf -b 512M -e 8G -f 2 -g 1 #-n 200 #-w 2 -n 20
                     "]
 

--- a/nccl-test-distributed-h100-64-las1-mpijob.yaml
+++ b/nccl-test-distributed-h100-64-las1-mpijob.yaml
@@ -29,7 +29,6 @@ spec:
                     -x NCCL_SOCKET_IFNAME=eth0 \
                     -x NCCL_IB_HCA=ibp \
                     -x UCX_NET_DEVICES=ibp0:1,ibp1:1,ibp2:1,ibp3:1,ibp4:1,ibp5:1,ibp6:1,ibp7:1 \
-                    -x NCCL_IB_PCI_RELAXED_ORDERING=1 \
                     -x SHARP_COLL_ENABLE_PCI_RELAXED_ORDERING=1 \
                     -x NCCL_COLLNET_ENABLE=0 \
                     -x NCCL_IB_PCI_RELAXED_ORDERING=0 \

--- a/nccl-test-distributed-h100-64-sharp-las1-mpijob.yaml
+++ b/nccl-test-distributed-h100-64-sharp-las1-mpijob.yaml
@@ -29,7 +29,6 @@ spec:
                     -x NCCL_SOCKET_IFNAME=eth0 \
                     -x NCCL_IB_HCA=ibp \
                     -x UCX_NET_DEVICES=ibp0:1,ibp1:1,ibp2:1,ibp3:1,ibp4:1,ibp5:1,ibp6:1,ibp7:1 \
-                    -x NCCL_IB_PCI_RELAXED_ORDERING=1 \
                     -x SHARP_COLL_ENABLE_PCI_RELAXED_ORDERING=1 \
                     -x NCCL_ALGO=COLLNETCHAIN \
                     -x NCCL_COLLNET_ENABLE=1 \

--- a/nccl-test-distributed-h100-64-sharp-las1-mpijob.yaml
+++ b/nccl-test-distributed-h100-64-sharp-las1-mpijob.yaml
@@ -33,7 +33,7 @@ spec:
                     -x SHARP_COLL_ENABLE_PCI_RELAXED_ORDERING=1 \
                     -x NCCL_ALGO=COLLNETCHAIN \
                     -x NCCL_COLLNET_ENABLE=1 \
-                    -x NCCL_PROTO=^LL128 \
+                    -x NCCL_IB_PCI_RELAXED_ORDERING=0 \
                     /opt/nccl_tests/build/all_reduce_perf -b 512M -e 8G -f 2 -g 1 #-n 200 #-w 2 -n 20
                     "]
 


### PR DESCRIPTION
Switch to the other solution for the known NCCL problem on H100s: https://docs.nvidia.com/deeplearning/nccl/release-notes/rel_2-18-1.html#rel_2-18-1