### PR TITLE
NCCL v2.18.3 & CUDA 12.2

### DIFF
--- a/.github/workflows/ubuntu-20.yml
+++ b/.github/workflows/ubuntu-20.yml
@@ -73,7 +73,7 @@ jobs:
       folder: .
       dockerfile: Dockerfile.ubuntu20
       base-image: nvidia/cuda
-      base-tag: 12.2.0-cudnn8-devel-ubuntu20.04
+      base-tag: 12.2.0-devel-ubuntu20.04
       cuda-version-minor: "12.2.0"
       cuda-version-major: "12.2"
       nccl-version: 2.18.3-1

--- a/.github/workflows/ubuntu-20.yml
+++ b/.github/workflows/ubuntu-20.yml
@@ -66,3 +66,18 @@ jobs:
       hpcx-version: "2.15"
       hpcx-nccl-version: "2.17"
       hpcx-cuda-version: "12"
+
+  cu122:
+    uses: ./.github/workflows/build.yml
+    with:
+      folder: .
+      dockerfile: Dockerfile.ubuntu20
+      base-image: nvidia/cuda
+      base-tag: 12.2.0-cudnn8-devel-ubuntu20.04
+      cuda-version-minor: "12.2.0"
+      cuda-version-major: "12.2"
+      nccl-version: 2.18.3-1
+      cuda-samples-version: "12.2"
+      hpcx-version: "2.15"
+      hpcx-nccl-version: "2.17"
+      hpcx-cuda-version: "12"

--- a/.github/workflows/ubuntu-20.yml
+++ b/.github/workflows/ubuntu-20.yml
@@ -46,7 +46,7 @@ jobs:
       base-tag: 12.0.1-cudnn8-devel-ubuntu20.04
       cuda-version-minor: "12.0.1"
       cuda-version-major: "12.0"
-      nccl-version: 2.18.1-1
+      nccl-version: 2.18.3-1
       cuda-samples-version: "12.0"
       hpcx-version: "2.15"
       hpcx-nccl-version: "2.17"
@@ -61,7 +61,7 @@ jobs:
       base-tag: 12.1.1-cudnn8-devel-ubuntu20.04
       cuda-version-minor: "12.1.1"
       cuda-version-major: "12.1"
-      nccl-version: 2.18.1-1
+      nccl-version: 2.18.3-1
       cuda-samples-version: "12.1"
       hpcx-version: "2.15"
       hpcx-nccl-version: "2.17"

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ built from these Dockerfiles that can be used as base for your own images.
 
 | **Image Tag**                                                                     | **CUDA** | **NCCL** | **HPC-X** |
 |-----------------------------------------------------------------------------------|----------|----------|-----------|
+| ghcr.io/coreweave/nccl-tests:12.2.0-devel-ubuntu20.04-nccl2.18.3-1-471f0db        | 12.2.0   | 2.18.3   | 2.15.0    |
 | ghcr.io/coreweave/nccl-tests:12.1.1-cudnn8-devel-ubuntu20.04-nccl2.18.3-1-471f0db | 12.1.1   | 2.18.3   | 2.15.0    |
 | ghcr.io/coreweave/nccl-tests:12.0.1-cudnn8-devel-ubuntu20.04-nccl2.18.3-1-471f0db | 12.0.1   | 2.18.3   | 2.15.0    |
 | ghcr.io/coreweave/nccl-tests:11.8.0-cudnn8-devel-ubuntu20.04-nccl2.16.2-1-471f0db | 11.8.0   | 2.16.2   | 2.14.0    |

--- a/README.md
+++ b/README.md
@@ -52,10 +52,10 @@ built from these Dockerfiles that can be used as base for your own images.
 
 | **Image Tag**                                                                     | **CUDA** | **NCCL** | **HPC-X** |
 |-----------------------------------------------------------------------------------|----------|----------|-----------|
-| ghcr.io/coreweave/nccl-tests:12.1.1-cudnn8-devel-ubuntu20.04-nccl2.18.1-1-29e3624 | 12.1.1   | 2.18.1   | 2.15.0    |
-| ghcr.io/coreweave/nccl-tests:12.0.1-cudnn8-devel-ubuntu20.04-nccl2.18.1-1-29e3624 | 12.0.1   | 2.18.1   | 2.15.0    |
-| ghcr.io/coreweave/nccl-tests:11.8.0-cudnn8-devel-ubuntu20.04-nccl2.16.2-1-29e3624 | 11.8.0   | 2.16.2   | 2.14.0    |
-| ghcr.io/coreweave/nccl-tests:11.7.1-cudnn8-devel-ubuntu20.04-nccl2.14.3-1-29e3624 | 11.7.1   | 2.14.3   | 2.14.0    |
+| ghcr.io/coreweave/nccl-tests:12.1.1-cudnn8-devel-ubuntu20.04-nccl2.18.3-1-471f0db | 12.1.1   | 2.18.3   | 2.15.0    |
+| ghcr.io/coreweave/nccl-tests:12.0.1-cudnn8-devel-ubuntu20.04-nccl2.18.3-1-471f0db | 12.0.1   | 2.18.3   | 2.15.0    |
+| ghcr.io/coreweave/nccl-tests:11.8.0-cudnn8-devel-ubuntu20.04-nccl2.16.2-1-471f0db | 11.8.0   | 2.16.2   | 2.14.0    |
+| ghcr.io/coreweave/nccl-tests:11.7.1-cudnn8-devel-ubuntu20.04-nccl2.14.3-1-471f0db | 11.7.1   | 2.14.3   | 2.14.0    |
 | coreweave/nccl-tests:2022-09-28_16-34-19.392_EDT                                  | 11.6.2   | 2.12.0   | 2.12      |
 
 ## Running NCCL Tests

--- a/mpi-operator/nccl-test-distributed-h100-64-las1-mpijob.yaml
+++ b/mpi-operator/nccl-test-distributed-h100-64-las1-mpijob.yaml
@@ -12,7 +12,7 @@ spec:
       template:
           spec:
             containers:
-            - image: ghcr.io/coreweave/nccl-tests:12.1.1-cudnn8-devel-ubuntu20.04-nccl2.18.1-1-29e3624
+            - image: ghcr.io/coreweave/nccl-tests:12.1.1-cudnn8-devel-ubuntu20.04-nccl2.18.3-1-471f0db
               name: nccl
               env:
               - name: OMPI_ALLOW_RUN_AS_ROOT
@@ -31,7 +31,6 @@ spec:
                     -x UCX_NET_DEVICES=ibp0:1,ibp1:1,ibp2:1,ibp3:1,ibp4:1,ibp5:1,ibp6:1,ibp7:1 \
                     -x SHARP_COLL_ENABLE_PCI_RELAXED_ORDERING=1 \
                     -x NCCL_COLLNET_ENABLE=0 \
-                    -x NCCL_IB_PCI_RELAXED_ORDERING=0 \
                     /opt/nccl_tests/build/all_reduce_perf -b 512M -e 8G -f 2 -g 1 #-n 200 #-w 2 -n 20
                     "]
 
@@ -59,7 +58,7 @@ spec:
           metadata.coreweave.cloud/job: nccl-test
         spec:
           containers:
-          - image: ghcr.io/coreweave/nccl-tests:12.1.1-cudnn8-devel-ubuntu20.04-nccl2.18.1-1-29e3624
+          - image: ghcr.io/coreweave/nccl-tests:12.1.1-cudnn8-devel-ubuntu20.04-nccl2.18.3-1-471f0db
             name: nccl
             resources:
               requests:

--- a/mpi-operator/nccl-test-distributed-h100-64-sharp-las1-mpijob.yaml
+++ b/mpi-operator/nccl-test-distributed-h100-64-sharp-las1-mpijob.yaml
@@ -12,7 +12,7 @@ spec:
       template:
           spec:
             containers:
-            - image: ghcr.io/coreweave/nccl-tests:12.1.1-cudnn8-devel-ubuntu20.04-nccl2.18.1-1-29e3624
+            - image: ghcr.io/coreweave/nccl-tests:12.1.1-cudnn8-devel-ubuntu20.04-nccl2.18.3-1-471f0db
               name: nccl
               env:
               - name: OMPI_ALLOW_RUN_AS_ROOT
@@ -32,7 +32,6 @@ spec:
                     -x SHARP_COLL_ENABLE_PCI_RELAXED_ORDERING=1 \
                     -x NCCL_ALGO=COLLNETCHAIN \
                     -x NCCL_COLLNET_ENABLE=1 \
-                    -x NCCL_IB_PCI_RELAXED_ORDERING=0 \
                     /opt/nccl_tests/build/all_reduce_perf -b 512M -e 8G -f 2 -g 1 #-n 200 #-w 2 -n 20
                     "]
 
@@ -60,7 +59,7 @@ spec:
           metadata.coreweave.cloud/job: nccl-test
         spec:
           containers:
-          - image: ghcr.io/coreweave/nccl-tests:12.1.1-cudnn8-devel-ubuntu20.04-nccl2.18.1-1-29e3624
+          - image: ghcr.io/coreweave/nccl-tests:12.1.1-cudnn8-devel-ubuntu20.04-nccl2.18.3-1-471f0db
             name: nccl
             resources:
               requests:

--- a/slurm/nccl-test-distributed-a100-64-enroot.slurm
+++ b/slurm/nccl-test-distributed-a100-64-enroot.slurm
@@ -8,13 +8,16 @@
 #SBATCH --output="%x.out"
 #SBATCH --exclusive
 
+# NCCL environment variables are documented at:
+# https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/env.html
+
 export NCCL_SOCKET_IFNAME=eth0
 export NCCL_IB_HCA=ibp
 export UCX_NET_DEVICES=ibp0:1,ibp1:1,ibp2:1,ibp3:1
 
-# log the assigned nodes
+# Log the assigned nodes
 echo "Using nodes: $SLURM_JOB_NODELIST"
 
-srun --container-image=ghcr.io#coreweave/nccl-tests:12.1.1-cudnn8-devel-ubuntu20.04-nccl2.18.1-1-29e3624 \
+srun --container-image=ghcr.io#coreweave/nccl-tests:12.1.1-cudnn8-devel-ubuntu20.04-nccl2.18.3-1-471f0db \
      --container-remap-root --no-container-mount-home \
      /opt/nccl-tests/build/all_reduce_perf -b 8 -e 8G -f 2 -g 1 -w 1 -n 10

--- a/slurm/nccl-test-distributed-a100-64.slurm
+++ b/slurm/nccl-test-distributed-a100-64.slurm
@@ -10,11 +10,14 @@
 
 module load image-defaults
 
+# NCCL environment variables are documented at:
+# https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/env.html
+
 export NCCL_SOCKET_IFNAME=eth0
 export NCCL_IB_HCA=ibp
 export UCX_NET_DEVICES=ibp0:1,ibp1:1,ibp2:1,ibp3:1
 
-# log the assigned nodes
+# Log the assigned nodes
 echo "Using nodes: $SLURM_JOB_NODELIST"
 
 srun /opt/nccl_tests/build/all_reduce_perf -b 8 -e 8G -f 2 -g 1 -w 1 -n 10

--- a/slurm/nccl-test-distributed-h100-64-enroot-sharp.slurm
+++ b/slurm/nccl-test-distributed-h100-64-enroot-sharp.slurm
@@ -8,6 +8,9 @@
 #SBATCH --output="%x.out"
 #SBATCH --exclusive
 
+# NCCL environment variables are documented at:
+# https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/env.html
+
 export NCCL_SOCKET_IFNAME=eth0
 export NCCL_IB_HCA=ibp
 export UCX_NET_DEVICES=ibp0:1,ibp1:1,ibp2:1,ibp3:1,ibp4:1,ibp5:1,ibp6:1,ibp7:1
@@ -23,14 +26,15 @@ export UCX_TLS=dc,self
 # Enable network collections
 export NCCL_COLLNET_ENABLE=1
 
-# Relaxed oredering should normally be disabled, but due to a known issue with
-# H100 it is currently disabled. Should re-enable once bug is fixed.
+# Relaxed ordering is fixed in NCCL 2.18.3+, but
+# in NCCL 2.18.1 and earlier it should be disabled
+# for H100s due to a bug. See:
 # https://docs.nvidia.com/deeplearning/nccl/archives/nccl_2181/release-notes/rel_2-18-1.html
-export NCCL_IB_PCI_RELAXED_ORDERING=0
+# export NCCL_IB_PCI_RELAXED_ORDERING=0
 
-# log the assigned nodes
+# Log the assigned nodes
 echo "Using nodes: $SLURM_JOB_NODELIST"
 
-srun --container-image=ghcr.io#coreweave/nccl-tests:12.1.1-cudnn8-devel-ubuntu20.04-nccl2.18.1-1-29e3624 \
+srun --container-image=ghcr.io#coreweave/nccl-tests:12.1.1-cudnn8-devel-ubuntu20.04-nccl2.18.3-1-471f0db \
      --container-remap-root --no-container-mount-home \
      /opt/nccl_tests/build/all_reduce_perf -b 512M -e 8G -f 2 -g 1

--- a/slurm/nccl-test-distributed-h100-64-enroot.slurm
+++ b/slurm/nccl-test-distributed-h100-64-enroot.slurm
@@ -8,20 +8,24 @@
 #SBATCH --output="%x.out"
 #SBATCH --exclusive
 
+# NCCL environment variables are documented at:
+# https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/env.html
+
 export NCCL_SOCKET_IFNAME=eth0
 export NCCL_IB_HCA=ibp
 export UCX_NET_DEVICES=ibp0:1,ibp1:1,ibp2:1,ibp3:1,ibp4:1,ibp5:1,ibp6:1,ibp7:1
 export SHARP_COLL_ENABLE_PCI_RELAXED_ORDERING=1
 export NCCL_COLLNET_ENABLE=0
 
-# Relaxed oredering should normally be disabled, but due to a known issue with
-# H100 it is currently disabled. Should re-enable once bug is fixed.
+# Relaxed ordering is fixed in NCCL 2.18.3+, but
+# in NCCL 2.18.1 and earlier it should be disabled
+# for H100s due to a bug. See:
 # https://docs.nvidia.com/deeplearning/nccl/archives/nccl_2181/release-notes/rel_2-18-1.html
-export NCCL_IB_PCI_RELAXED_ORDERING=0
+# export NCCL_IB_PCI_RELAXED_ORDERING=0
 
-# log the assigned nodes
+# Log the assigned nodes
 echo "Using nodes: $SLURM_JOB_NODELIST"
 
-srun --container-image=ghcr.io#coreweave/nccl-tests:12.1.1-cudnn8-devel-ubuntu20.04-nccl2.18.1-1-29e3624 \
+srun --container-image=ghcr.io#coreweave/nccl-tests:12.1.1-cudnn8-devel-ubuntu20.04-nccl2.18.3-1-471f0db \
      --container-remap-root --no-container-mount-home \
      /opt/nccl_tests/build/all_reduce_perf -b 512M -e 8G -f 2 -g 1

--- a/slurm/nccl-test-distributed-h100-64.slurm
+++ b/slurm/nccl-test-distributed-h100-64.slurm
@@ -10,18 +10,22 @@
 
 module load image-defaults
 
+# NCCL environment variables are documented at:
+# https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/env.html
+
 export NCCL_SOCKET_IFNAME=eth0
 export NCCL_IB_HCA=ibp
 export UCX_NET_DEVICES=ibp0:1,ibp1:1,ibp2:1,ibp3:1,ibp4:1,ibp5:1,ibp6:1,ibp7:1
 export SHARP_COLL_ENABLE_PCI_RELAXED_ORDERING=1
 export NCCL_COLLNET_ENABLE=0
 
-# Relaxed oredering should normally be disabled, but due to a known issue with
-# H100 it is currently disabled
+# Relaxed ordering is fixed in NCCL 2.18.3+, but
+# in NCCL 2.18.1 and earlier it should be disabled
+# for H100s due to a bug. See:
 # https://docs.nvidia.com/deeplearning/nccl/archives/nccl_2181/release-notes/rel_2-18-1.html
-export NCCL_IB_PCI_RELAXED_ORDERING=0
+# export NCCL_IB_PCI_RELAXED_ORDERING=0
 
-# log the assigned nodes
+# Log the assigned nodes
 echo "Using nodes: $SLURM_JOB_NODELIST"
 
 srun /opt/nccl_tests/build/all_reduce_perf -b 512M -e 8G -f 2 -g 1


### PR DESCRIPTION
This change updates the [NCCL version to v2.18.3](https://github.com/NVIDIA/nccl/releases/tag/v2.18.3-1) for all CUDA 12 builds, and adds a new build with [CUDA 12.2.0](https://hub.docker.com/r/nvidia/cuda/tags?name=12.2.0-devel-ubuntu20.04).

There is no cuDNN release officially supporting CUDA 12.2 yet, so this builds the CUDA 12.2 image off of `nvidia/cuda:12.2.0-devel-ubuntu20.04` rather than `nvidia/cuda:12.2.0-cudnn8-devel-ubuntu20.04` (which does not yet exist).