### PR TITLE
build: Update HPC-X to v2.16 for CUDA 12 builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,6 +36,9 @@ on:
       hpcx-cuda-version:
         required: true
         type: string
+      hpcx-mlnx-ofed:
+        required: true
+        type: string
 
 jobs:
   build:
@@ -79,6 +82,7 @@ jobs:
             HPCX_VERSION=${{ inputs.hpcx-version }}
             HPCX_NCCL_VERSION=${{ inputs.hpcx-nccl-version }}
             HPCX_CUDA_VERSION=${{ inputs.hpcx-cuda-version }}
+            HPCX_MLNX_OFED=${{ inputs.hpcx-mlnx-ofed }}
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/ubuntu-20.yml
+++ b/.github/workflows/ubuntu-20.yml
@@ -21,6 +21,7 @@ jobs:
       hpcx-version: "2.14"
       hpcx-nccl-version: "2.16"
       hpcx-cuda-version: "11"
+      hpcx-mlnx-ofed: "MLNX_OFED_LINUX-5"
 
   cu118:
     uses: ./.github/workflows/build.yml
@@ -36,6 +37,7 @@ jobs:
       hpcx-version: "2.14"
       hpcx-nccl-version: "2.16"
       hpcx-cuda-version: "11"
+      hpcx-mlnx-ofed: "MLNX_OFED_LINUX-5"
 
   cu120:
     uses: ./.github/workflows/build.yml
@@ -48,9 +50,10 @@ jobs:
       cuda-version-major: "12.0"
       nccl-version: 2.18.3-1
       cuda-samples-version: "12.0"
-      hpcx-version: "2.15"
-      hpcx-nccl-version: "2.17"
+      hpcx-version: "2.16"
+      hpcx-nccl-version: "2.18"
       hpcx-cuda-version: "12"
+      hpcx-mlnx-ofed: "mlnx_ofed"
 
   cu121:
     uses: ./.github/workflows/build.yml
@@ -63,9 +66,10 @@ jobs:
       cuda-version-major: "12.1"
       nccl-version: 2.18.3-1
       cuda-samples-version: "12.1"
-      hpcx-version: "2.15"
-      hpcx-nccl-version: "2.17"
+      hpcx-version: "2.16"
+      hpcx-nccl-version: "2.18"
       hpcx-cuda-version: "12"
+      hpcx-mlnx-ofed: "mlnx_ofed"
 
   cu122:
     uses: ./.github/workflows/build.yml
@@ -78,6 +82,7 @@ jobs:
       cuda-version-major: "12.2"
       nccl-version: 2.18.3-1
       cuda-samples-version: "12.2"
-      hpcx-version: "2.15"
-      hpcx-nccl-version: "2.17"
+      hpcx-version: "2.16"
+      hpcx-nccl-version: "2.18"
       hpcx-cuda-version: "12"
+      hpcx-mlnx-ofed: "mlnx_ofed"

--- a/Dockerfile.ubuntu20
+++ b/Dockerfile.ubuntu20
@@ -59,8 +59,9 @@ RUN mkdir /tmp/build && \
 ARG HPCX_VERSION=2.14
 ARG HPCX_NCCL_VERSION=2.16
 ARG HPCX_CUDA_VERSION=11
+ARG HPCX_MLNX_OFED="MLNX_OFED_LINUX-5"
 RUN cd /tmp && \
-    export HPCX_DISTRIBUTION="hpcx-v${HPCX_VERSION}-gcc-MLNX_OFED_LINUX-5-ubuntu20.04-cuda${HPCX_CUDA_VERSION}-gdrcopy2-nccl${HPCX_NCCL_VERSION}-x86_64" \
+    export HPCX_DISTRIBUTION="hpcx-v${HPCX_VERSION}-gcc-${HPCX_MLNX_OFED}-ubuntu20.04-cuda${HPCX_CUDA_VERSION}-gdrcopy2-nccl${HPCX_NCCL_VERSION}-x86_64" \
            HPCX_DIR="/opt/hpcx" && \
     wget -q -O - http://blobstore.s3.ord1.coreweave.com/drivers/${HPCX_DISTRIBUTION}.tbz | tar xjf - && \
     grep -IrlF "/build-result/${HPCX_DISTRIBUTION}" ${HPCX_DISTRIBUTION} | xargs -rd'\n' sed -i -e "s:/build-result/${HPCX_DISTRIBUTION}:${HPCX_DIR}:g" && \

--- a/README.md
+++ b/README.md
@@ -52,11 +52,11 @@ built from these Dockerfiles that can be used as base for your own images.
 
 | **Image Tag**                                                                     | **CUDA** | **NCCL** | **HPC-X** |
 |-----------------------------------------------------------------------------------|----------|----------|-----------|
-| ghcr.io/coreweave/nccl-tests:12.2.0-devel-ubuntu20.04-nccl2.18.3-1-471f0db        | 12.2.0   | 2.18.3   | 2.15.0    |
-| ghcr.io/coreweave/nccl-tests:12.1.1-cudnn8-devel-ubuntu20.04-nccl2.18.3-1-471f0db | 12.1.1   | 2.18.3   | 2.15.0    |
-| ghcr.io/coreweave/nccl-tests:12.0.1-cudnn8-devel-ubuntu20.04-nccl2.18.3-1-471f0db | 12.0.1   | 2.18.3   | 2.15.0    |
-| ghcr.io/coreweave/nccl-tests:11.8.0-cudnn8-devel-ubuntu20.04-nccl2.16.2-1-471f0db | 11.8.0   | 2.16.2   | 2.14.0    |
-| ghcr.io/coreweave/nccl-tests:11.7.1-cudnn8-devel-ubuntu20.04-nccl2.14.3-1-471f0db | 11.7.1   | 2.14.3   | 2.14.0    |
+| ghcr.io/coreweave/nccl-tests:12.2.0-devel-ubuntu20.04-nccl2.18.3-1-253a5b1        | 12.2.0   | 2.18.3   | 2.16.0    |
+| ghcr.io/coreweave/nccl-tests:12.1.1-cudnn8-devel-ubuntu20.04-nccl2.18.3-1-253a5b1 | 12.1.1   | 2.18.3   | 2.16.0    |
+| ghcr.io/coreweave/nccl-tests:12.0.1-cudnn8-devel-ubuntu20.04-nccl2.18.3-1-253a5b1 | 12.0.1   | 2.18.3   | 2.16.0    |
+| ghcr.io/coreweave/nccl-tests:11.8.0-cudnn8-devel-ubuntu20.04-nccl2.16.2-1-253a5b1 | 11.8.0   | 2.16.2   | 2.14.0    |
+| ghcr.io/coreweave/nccl-tests:11.7.1-cudnn8-devel-ubuntu20.04-nccl2.14.3-1-253a5b1 | 11.7.1   | 2.14.3   | 2.14.0    |
 | coreweave/nccl-tests:2022-09-28_16-34-19.392_EDT                                  | 11.6.2   | 2.12.0   | 2.12      |
 
 ## Running NCCL Tests


### PR DESCRIPTION
# HPC-X v2.16

This change updates all CUDA 12 build configurations to use HPC-X v2.16, and adds an extra build argument to the Dockerfile for controlling another part of the distribution name that has changed in the latest update (`MLNX_OFED_LINUX-5` → `mlnx_ofed`).