### PR TITLE
build: Update to NCCL v2.18.5 & CUDA 12.2.2

### DIFF
--- a/.github/workflows/ubuntu-20.yml
+++ b/.github/workflows/ubuntu-20.yml
@@ -77,8 +77,8 @@ jobs:
       folder: .
       dockerfile: Dockerfile.ubuntu20
       base-image: nvidia/cuda
-      base-tag: 12.2.0-devel-ubuntu20.04
-      cuda-version-minor: "12.2.0"
+      base-tag: 12.2.2-cudnn8-devel-ubuntu20.04
+      cuda-version-minor: "12.2.2"
       cuda-version-major: "12.2"
       nccl-version: 2.18.3-1
       cuda-samples-version: "12.2"

--- a/.github/workflows/ubuntu-20.yml
+++ b/.github/workflows/ubuntu-20.yml
@@ -48,7 +48,7 @@ jobs:
       base-tag: 12.0.1-cudnn8-devel-ubuntu20.04
       cuda-version-minor: "12.0.1"
       cuda-version-major: "12.0"
-      nccl-version: 2.18.3-1
+      nccl-version: 2.18.6-1
       cuda-samples-version: "12.0"
       hpcx-version: "2.16"
       hpcx-nccl-version: "2.18"
@@ -64,7 +64,7 @@ jobs:
       base-tag: 12.1.1-cudnn8-devel-ubuntu20.04
       cuda-version-minor: "12.1.1"
       cuda-version-major: "12.1"
-      nccl-version: 2.18.3-1
+      nccl-version: 2.18.6-1
       cuda-samples-version: "12.1"
       hpcx-version: "2.16"
       hpcx-nccl-version: "2.18"
@@ -80,7 +80,7 @@ jobs:
       base-tag: 12.2.2-cudnn8-devel-ubuntu20.04
       cuda-version-minor: "12.2.2"
       cuda-version-major: "12.2"
-      nccl-version: 2.18.3-1
+      nccl-version: 2.18.6-1
       cuda-samples-version: "12.2"
       hpcx-version: "2.16"
       hpcx-nccl-version: "2.18"

--- a/.github/workflows/ubuntu-20.yml
+++ b/.github/workflows/ubuntu-20.yml
@@ -64,7 +64,7 @@ jobs:
       base-tag: 12.1.1-cudnn8-devel-ubuntu20.04
       cuda-version-minor: "12.1.1"
       cuda-version-major: "12.1"
-      nccl-version: 2.18.5-1
+      nccl-version: 2.18.3-1
       cuda-samples-version: "12.1"
       hpcx-version: "2.16"
       hpcx-nccl-version: "2.18"

--- a/.github/workflows/ubuntu-20.yml
+++ b/.github/workflows/ubuntu-20.yml
@@ -48,7 +48,7 @@ jobs:
       base-tag: 12.0.1-cudnn8-devel-ubuntu20.04
       cuda-version-minor: "12.0.1"
       cuda-version-major: "12.0"
-      nccl-version: 2.18.6-1
+      nccl-version: 2.18.5-1
       cuda-samples-version: "12.0"
       hpcx-version: "2.16"
       hpcx-nccl-version: "2.18"
@@ -64,7 +64,7 @@ jobs:
       base-tag: 12.1.1-cudnn8-devel-ubuntu20.04
       cuda-version-minor: "12.1.1"
       cuda-version-major: "12.1"
-      nccl-version: 2.18.6-1
+      nccl-version: 2.18.5-1
       cuda-samples-version: "12.1"
       hpcx-version: "2.16"
       hpcx-nccl-version: "2.18"
@@ -80,7 +80,7 @@ jobs:
       base-tag: 12.2.2-cudnn8-devel-ubuntu20.04
       cuda-version-minor: "12.2.2"
       cuda-version-major: "12.2"
-      nccl-version: 2.18.6-1
+      nccl-version: 2.18.5-1
       cuda-samples-version: "12.2"
       hpcx-version: "2.16"
       hpcx-nccl-version: "2.18"

--- a/Dockerfile.ubuntu20
+++ b/Dockerfile.ubuntu20
@@ -20,7 +20,7 @@ RUN apt-get -qq update && \
 
 # Mellanox OFED (latest)
 RUN wget -qO - https://www.mellanox.com/downloads/ofed/RPM-GPG-KEY-Mellanox | apt-key add -
-RUN cd /etc/apt/sources.list.d/ && wget https://linux.mellanox.com/public/repo/mlnx_ofed/latest/ubuntu18.04/mellanox_mlnx_ofed.list
+RUN cd /etc/apt/sources.list.d/ && wget https://linux.mellanox.com/public/repo/mlnx_ofed/latest/ubuntu20.04/mellanox_mlnx_ofed.list
 
 RUN apt-get -qq update \
     && apt-get -qq install -y --no-install-recommends \

--- a/README.md
+++ b/README.md
@@ -52,11 +52,11 @@ built from these Dockerfiles that can be used as base for your own images.
 
 | **Image Tag**                                                                     | **CUDA** | **NCCL** | **HPC-X** |
 |-----------------------------------------------------------------------------------|----------|----------|-----------|
-| ghcr.io/coreweave/nccl-tests:12.2.2-cudnn8-devel-ubuntu20.04-nccl2.18.6-1-e34a4d6 | 12.2.2   | 2.18.6   | 2.16.0    |
-| ghcr.io/coreweave/nccl-tests:12.1.1-cudnn8-devel-ubuntu20.04-nccl2.18.6-1-e34a4d6 | 12.1.1   | 2.18.6   | 2.16.0    |
-| ghcr.io/coreweave/nccl-tests:12.0.1-cudnn8-devel-ubuntu20.04-nccl2.18.6-1-e34a4d6 | 12.0.1   | 2.18.6   | 2.16.0    |
-| ghcr.io/coreweave/nccl-tests:11.8.0-cudnn8-devel-ubuntu20.04-nccl2.16.2-1-e34a4d6 | 11.8.0   | 2.16.2   | 2.14.0    |
-| ghcr.io/coreweave/nccl-tests:11.7.1-cudnn8-devel-ubuntu20.04-nccl2.14.3-1-e34a4d6 | 11.7.1   | 2.14.3   | 2.14.0    |
+| ghcr.io/coreweave/nccl-tests:12.2.2-cudnn8-devel-ubuntu20.04-nccl2.18.5-1-c50cbae | 12.2.2   | 2.18.5   | 2.16.0    |
+| ghcr.io/coreweave/nccl-tests:12.1.1-cudnn8-devel-ubuntu20.04-nccl2.18.5-1-c50cbae | 12.1.1   | 2.18.5   | 2.16.0    |
+| ghcr.io/coreweave/nccl-tests:12.0.1-cudnn8-devel-ubuntu20.04-nccl2.18.5-1-c50cbae | 12.0.1   | 2.18.5   | 2.16.0    |
+| ghcr.io/coreweave/nccl-tests:11.8.0-cudnn8-devel-ubuntu20.04-nccl2.16.2-1-c50cbae | 11.8.0   | 2.16.2   | 2.14.0    |
+| ghcr.io/coreweave/nccl-tests:11.7.1-cudnn8-devel-ubuntu20.04-nccl2.14.3-1-c50cbae | 11.7.1   | 2.14.3   | 2.14.0    |
 | coreweave/nccl-tests:2022-09-28_16-34-19.392_EDT                                  | 11.6.2   | 2.12.0   | 2.12      |
 
 ## Running NCCL Tests

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ built from these Dockerfiles that can be used as base for your own images.
 | **Image Tag**                                                                     | **CUDA** | **NCCL** | **HPC-X** |
 |-----------------------------------------------------------------------------------|----------|----------|-----------|
 | ghcr.io/coreweave/nccl-tests:12.2.2-cudnn8-devel-ubuntu20.04-nccl2.18.5-1-a6a61ab | 12.2.2   | 2.18.5   | 2.16.0    |
-| ghcr.io/coreweave/nccl-tests:12.1.1-cudnn8-devel-ubuntu20.04-nccl2.18.5-1-a6a61ab | 12.1.1   | 2.18.5   | 2.16.0    |
+| ghcr.io/coreweave/nccl-tests:12.1.1-cudnn8-devel-ubuntu20.04-nccl2.18.3-1-253a5b1 | 12.1.1   | 2.18.3   | 2.16.0    |
 | ghcr.io/coreweave/nccl-tests:12.0.1-cudnn8-devel-ubuntu20.04-nccl2.18.5-1-a6a61ab | 12.0.1   | 2.18.5   | 2.16.0    |
 | ghcr.io/coreweave/nccl-tests:11.8.0-cudnn8-devel-ubuntu20.04-nccl2.16.2-1-a6a61ab | 11.8.0   | 2.16.2   | 2.14.0    |
 | ghcr.io/coreweave/nccl-tests:11.7.1-cudnn8-devel-ubuntu20.04-nccl2.14.3-1-a6a61ab | 11.7.1   | 2.14.3   | 2.14.0    |

--- a/README.md
+++ b/README.md
@@ -52,11 +52,11 @@ built from these Dockerfiles that can be used as base for your own images.
 
 | **Image Tag**                                                                     | **CUDA** | **NCCL** | **HPC-X** |
 |-----------------------------------------------------------------------------------|----------|----------|-----------|
-| ghcr.io/coreweave/nccl-tests:12.2.2-cudnn8-devel-ubuntu20.04-nccl2.18.5-1-c50cbae | 12.2.2   | 2.18.5   | 2.16.0    |
-| ghcr.io/coreweave/nccl-tests:12.1.1-cudnn8-devel-ubuntu20.04-nccl2.18.5-1-c50cbae | 12.1.1   | 2.18.5   | 2.16.0    |
-| ghcr.io/coreweave/nccl-tests:12.0.1-cudnn8-devel-ubuntu20.04-nccl2.18.5-1-c50cbae | 12.0.1   | 2.18.5   | 2.16.0    |
-| ghcr.io/coreweave/nccl-tests:11.8.0-cudnn8-devel-ubuntu20.04-nccl2.16.2-1-c50cbae | 11.8.0   | 2.16.2   | 2.14.0    |
-| ghcr.io/coreweave/nccl-tests:11.7.1-cudnn8-devel-ubuntu20.04-nccl2.14.3-1-c50cbae | 11.7.1   | 2.14.3   | 2.14.0    |
+| ghcr.io/coreweave/nccl-tests:12.2.2-cudnn8-devel-ubuntu20.04-nccl2.18.5-1-a6a61ab | 12.2.2   | 2.18.5   | 2.16.0    |
+| ghcr.io/coreweave/nccl-tests:12.1.1-cudnn8-devel-ubuntu20.04-nccl2.18.5-1-a6a61ab | 12.1.1   | 2.18.5   | 2.16.0    |
+| ghcr.io/coreweave/nccl-tests:12.0.1-cudnn8-devel-ubuntu20.04-nccl2.18.5-1-a6a61ab | 12.0.1   | 2.18.5   | 2.16.0    |
+| ghcr.io/coreweave/nccl-tests:11.8.0-cudnn8-devel-ubuntu20.04-nccl2.16.2-1-a6a61ab | 11.8.0   | 2.16.2   | 2.14.0    |
+| ghcr.io/coreweave/nccl-tests:11.7.1-cudnn8-devel-ubuntu20.04-nccl2.14.3-1-a6a61ab | 11.7.1   | 2.14.3   | 2.14.0    |
 | coreweave/nccl-tests:2022-09-28_16-34-19.392_EDT                                  | 11.6.2   | 2.12.0   | 2.12      |
 
 ## Running NCCL Tests

--- a/README.md
+++ b/README.md
@@ -52,11 +52,11 @@ built from these Dockerfiles that can be used as base for your own images.
 
 | **Image Tag**                                                                     | **CUDA** | **NCCL** | **HPC-X** |
 |-----------------------------------------------------------------------------------|----------|----------|-----------|
-| ghcr.io/coreweave/nccl-tests:12.2.0-devel-ubuntu20.04-nccl2.18.3-1-253a5b1        | 12.2.0   | 2.18.3   | 2.16.0    |
-| ghcr.io/coreweave/nccl-tests:12.1.1-cudnn8-devel-ubuntu20.04-nccl2.18.3-1-253a5b1 | 12.1.1   | 2.18.3   | 2.16.0    |
-| ghcr.io/coreweave/nccl-tests:12.0.1-cudnn8-devel-ubuntu20.04-nccl2.18.3-1-253a5b1 | 12.0.1   | 2.18.3   | 2.16.0    |
-| ghcr.io/coreweave/nccl-tests:11.8.0-cudnn8-devel-ubuntu20.04-nccl2.16.2-1-253a5b1 | 11.8.0   | 2.16.2   | 2.14.0    |
-| ghcr.io/coreweave/nccl-tests:11.7.1-cudnn8-devel-ubuntu20.04-nccl2.14.3-1-253a5b1 | 11.7.1   | 2.14.3   | 2.14.0    |
+| ghcr.io/coreweave/nccl-tests:12.2.2-cudnn8-devel-ubuntu20.04-nccl2.18.6-1-e34a4d6 | 12.2.2   | 2.18.6   | 2.16.0    |
+| ghcr.io/coreweave/nccl-tests:12.1.1-cudnn8-devel-ubuntu20.04-nccl2.18.6-1-e34a4d6 | 12.1.1   | 2.18.6   | 2.16.0    |
+| ghcr.io/coreweave/nccl-tests:12.0.1-cudnn8-devel-ubuntu20.04-nccl2.18.6-1-e34a4d6 | 12.0.1   | 2.18.6   | 2.16.0    |
+| ghcr.io/coreweave/nccl-tests:11.8.0-cudnn8-devel-ubuntu20.04-nccl2.16.2-1-e34a4d6 | 11.8.0   | 2.16.2   | 2.14.0    |
+| ghcr.io/coreweave/nccl-tests:11.7.1-cudnn8-devel-ubuntu20.04-nccl2.14.3-1-e34a4d6 | 11.7.1   | 2.14.3   | 2.14.0    |
 | coreweave/nccl-tests:2022-09-28_16-34-19.392_EDT                                  | 11.6.2   | 2.12.0   | 2.12      |
 
 ## Running NCCL Tests


### PR DESCRIPTION
# NCCL v2.18.5 & CUDA 12.2.2
This change updates the [NCCL version to v2.18.5](https://github.com/NVIDIA/nccl/releases/tag/v2.18.5-1) for all CUDA 12 builds.  It also updates the CUDA 12.2.0 image to [CUDA 12.2.2 with cuDNN](https://hub.docker.com/r/nvidia/cuda/tags?name=12.2.2-cudnn8-devel-ubuntu20.04).

[NCCL version v2.18.6](https://github.com/NVIDIA/nccl/releases/tag/v2.18.6-1) is tagged on the NCCL GitHub repository but has no official release by NVIDIA as of this time, so this PR is only for v2.18.5.