### PR TITLE
feat: Update NCCL, CUDA, cuDNN, and HPC-X

### DIFF
--- a/.github/workflows/ubuntu-20.yml
+++ b/.github/workflows/ubuntu-20.yml
@@ -31,7 +31,7 @@ jobs:
       cuda-version-major: "12.0"
       nccl-version: 2.19.3-1
       cuda-samples-version: "12.0"
-      hpcx-distribution: "hpcx-v2.16-gcc-mlnx_ofed-ubuntu20.04-cuda12-gdrcopy2-nccl2.18-x86_64"
+      hpcx-distribution: "hpcx-v2.18-gcc-mlnx_ofed-ubuntu20.04-cuda12-x86_64"
 
   cu121:
     uses: ./.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
       cuda-version-major: "12.1"
       nccl-version: 2.18.3-1
       cuda-samples-version: "12.1"
-      hpcx-distribution: "hpcx-v2.16-gcc-mlnx_ofed-ubuntu20.04-cuda12-gdrcopy2-nccl2.18-x86_64"
+      hpcx-distribution: "hpcx-v2.18-gcc-mlnx_ofed-ubuntu20.04-cuda12-x86_64"
 
   cu122:
     uses: ./.github/workflows/build.yml
@@ -55,19 +55,19 @@ jobs:
       base-tag: 12.2.2-cudnn8-devel-ubuntu20.04
       cuda-version-minor: "12.2.2"
       cuda-version-major: "12.2"
-      nccl-version: 2.19.3-1
+      nccl-version: 2.20.3-1
       cuda-samples-version: "12.2"
-      hpcx-distribution: "hpcx-v2.16-gcc-mlnx_ofed-ubuntu20.04-cuda12-gdrcopy2-nccl2.18-x86_64"
+      hpcx-distribution: "hpcx-v2.18-gcc-mlnx_ofed-ubuntu20.04-cuda12-x86_64"
 
-#  cu123:
-#    uses: ./.github/workflows/build.yml
-#    with:
-#      folder: .
-#      dockerfile: Dockerfile.ubuntu20
-#      base-image: nvidia/cuda
-#      base-tag: 12.3.0-cudnn8-devel-ubuntu20.04
-#      cuda-version-minor: "12.3.0"
-#      cuda-version-major: "12.3"
-#      nccl-version: 2.19.3-1
-#      cuda-samples-version: "12.3"
-#      hpcx-distribution: "hpcx-v2.17-gcc-mlnx_ofed-ubuntu20.04-cuda12-x86_64"
+  cu123:
+    uses: ./.github/workflows/build.yml
+    with:
+      folder: .
+      dockerfile: Dockerfile.ubuntu20
+      base-image: nvidia/cuda
+      base-tag: 12.3.2-cudnn9-devel-ubuntu20.04
+      cuda-version-minor: "12.3.2"
+      cuda-version-major: "12.3"
+      nccl-version: 2.20.3-1
+      cuda-samples-version: "12.3"
+      hpcx-distribution: "hpcx-v2.18-gcc-mlnx_ofed-ubuntu20.04-cuda12-x86_64"

--- a/.github/workflows/ubuntu-22.yml
+++ b/.github/workflows/ubuntu-22.yml
@@ -18,7 +18,7 @@ jobs:
       cuda-version-major: "12.0"
       nccl-version: 2.18.5-1
       cuda-samples-version: "12.0"
-      hpcx-distribution: "hpcx-v2.17-gcc-mlnx_ofed-ubuntu22.04-cuda12-x86_64"
+      hpcx-distribution: "hpcx-v2.18-gcc-mlnx_ofed-ubuntu22.04-cuda12-x86_64"
 
   cu121:
     uses: ./.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
       cuda-version-major: "12.1"
       nccl-version: 2.18.3-1
       cuda-samples-version: "12.1"
-      hpcx-distribution: "hpcx-v2.17-gcc-mlnx_ofed-ubuntu22.04-cuda12-x86_64"
+      hpcx-distribution: "hpcx-v2.18-gcc-mlnx_ofed-ubuntu22.04-cuda12-x86_64"
 
   cu122:
     uses: ./.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
       cuda-version-major: "12.2"
       nccl-version: 2.19.3-1
       cuda-samples-version: "12.2"
-      hpcx-distribution: "hpcx-v2.17-gcc-mlnx_ofed-ubuntu22.04-cuda12-x86_64"
+      hpcx-distribution: "hpcx-v2.18-gcc-mlnx_ofed-ubuntu22.04-cuda12-x86_64"
 
   cu123:
     uses: ./.github/workflows/build.yml
@@ -52,9 +52,9 @@ jobs:
       folder: .
       dockerfile: Dockerfile.ubuntu22
       base-image: nvidia/cuda
-      base-tag: 12.3.1-devel-ubuntu22.04
-      cuda-version-minor: "12.3.1"
+      base-tag: 12.3.2-cudnn9-devel-ubuntu22.04
+      cuda-version-minor: "12.3.2"
       cuda-version-major: "12.3"
-      nccl-version: 2.19.3-1
+      nccl-version: 2.20.3-1
       cuda-samples-version: "12.3"
-      hpcx-distribution: "hpcx-v2.17-gcc-mlnx_ofed-ubuntu22.04-cuda12-x86_64"
+      hpcx-distribution: "hpcx-v2.18-gcc-mlnx_ofed-ubuntu22.04-cuda12-x86_64"

--- a/Dockerfile.ubuntu20
+++ b/Dockerfile.ubuntu20
@@ -63,7 +63,7 @@ RUN mkdir /tmp/build && \
 ARG HPCX_DISTRIBUTION="hpcx-v2.14-gcc-MLNX_OFED_LINUX-5-ubuntu20.04-cuda11-gdrcopy2-nccl2.16-x86_64"
 RUN cd /tmp && \
     export HPCX_DIR="/opt/hpcx" && \
-    wget -q -O - http://blobstore.object.ord1.coreweave.com/drivers/${HPCX_DISTRIBUTION}.tbz | tar xjf - && \
+    wget -q -O - https://blobstore.object.ord1.coreweave.com/drivers/${HPCX_DISTRIBUTION}.tbz | tar xjf - && \
     grep -IrlF "/build-result/${HPCX_DISTRIBUTION}" ${HPCX_DISTRIBUTION} | xargs -rd'\n' sed -i -e "s:/build-result/${HPCX_DISTRIBUTION}:${HPCX_DIR}:g" && \
     mv ${HPCX_DISTRIBUTION} ${HPCX_DIR}
 

--- a/Dockerfile.ubuntu22
+++ b/Dockerfile.ubuntu22
@@ -62,10 +62,10 @@ RUN mkdir /tmp/build && \
 
 # HPC-X
 # grep + sed is used as a workaround to update hardcoded pkg-config / libtools archive / CMake prefixes
-ARG HPCX_DISTRIBUTION="hpcx-v2.17-gcc-mlnx_ofed-ubuntu22.04-cuda12-x86_64"
+ARG HPCX_DISTRIBUTION="hpcx-v2.18-gcc-mlnx_ofed-ubuntu22.04-cuda12-x86_64"
 RUN cd /tmp && \
     export HPCX_DIR="/opt/hpcx" && \
-    wget -q -O - http://blobstore.object.ord1.coreweave.com/drivers/${HPCX_DISTRIBUTION}.tbz | tar xjf - && \
+    wget -q -O - https://blobstore.object.ord1.coreweave.com/drivers/${HPCX_DISTRIBUTION}.tbz | tar xjf - && \
     grep -IrlF "/build-result/${HPCX_DISTRIBUTION}" ${HPCX_DISTRIBUTION} | xargs -rd'\n' sed -i -e "s:/build-result/${HPCX_DISTRIBUTION}:${HPCX_DIR}:g" && \
     mv ${HPCX_DISTRIBUTION} ${HPCX_DIR}
 


### PR DESCRIPTION
# Many Updates!

This change updates the following components:

## NCCL

NCCL is updated to version 2.20.3-1 for supported CUDA & OS versions, which are:
- CUDA 12.2 & 12.3 with Ubuntu 20.04
- CUDA 12.3 only with Ubuntu 22.04

## CUDA

The CUDA 12.3 releases have been bumped to the 12.3.2 patch, and the CUDA 12.3 × Ubuntu 20.04 build has been enabled, since it had been commented out previously due to issues that should already be fixed.

## cuDNN

The CUDA 12.3 releases now use the newest version of cuDNN: [cuDNN 9](https://docs.nvidia.com/deeplearning/cudnn/release-notes.html#cudnn-9-0-0). This is exclusively available for CUDA 12.3 and the only cuDNN version available for CUDA 12.3, with the `nvidia/cuda` base images.

As noted in the cuDNN 9 release notes:

> This is the first major version bump of cuDNN in almost 4 years. There are some exciting new features and also some changes that may be disruptive to current applications built against prior versions of cuDNN.

So there may or may not be downstream compatibility issues to work out (for example, with the PyTorch builds in [coreweave/ml-containers](https://github.com/coreweave/ml-containers)), but it should not be more disruptive than these images' previous state of not having a cuDNN distribution included at all.

## HPC-X

The HPC-X distribution is updated from 2.16 & 2.17 to 2.18 on all CUDA 12 releases.