### PR TITLE
docs: Update README with new image tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,15 +52,16 @@ built from these Dockerfiles that can be used as base for your own images.
 
 | **Image Tag**                                                                     | **Ubuntu** | **CUDA** | **NCCL** | **HPC-X** |
 |-----------------------------------------------------------------------------------|------------|----------|----------|-----------|
-| ghcr.io/coreweave/nccl-tests:12.2.2-cudnn8-devel-ubuntu20.04-nccl2.19.3-1-3e0fbc3 | 20.04      | 12.2.2   | 2.19.3   | 2.16.0    |
-| ghcr.io/coreweave/nccl-tests:12.1.1-cudnn8-devel-ubuntu20.04-nccl2.18.3-1-3e0fbc3 | 20.04      | 12.1.1   | 2.18.3   | 2.16.0    |
-| ghcr.io/coreweave/nccl-tests:12.0.1-cudnn8-devel-ubuntu20.04-nccl2.19.3-1-3e0fbc3 | 20.04      | 12.0.1   | 2.19.3   | 2.16.0    |
-| ghcr.io/coreweave/nccl-tests:11.8.0-cudnn8-devel-ubuntu20.04-nccl2.16.5-1-3e0fbc3 | 20.04      | 11.8.0   | 2.16.5   | 2.14.0    |
+| ghcr.io/coreweave/nccl-tests:12.3.2-cudnn9-devel-ubuntu20.04-nccl2.20.3-1-868dc3d | 20.04      | 12.3.2   | 2.20.3   | 2.18.0    |
+| ghcr.io/coreweave/nccl-tests:12.2.2-cudnn8-devel-ubuntu20.04-nccl2.20.3-1-868dc3d | 20.04      | 12.2.2   | 2.20.3   | 2.18.0    |
+| ghcr.io/coreweave/nccl-tests:12.1.1-cudnn8-devel-ubuntu20.04-nccl2.18.3-1-868dc3d | 20.04      | 12.1.1   | 2.18.3   | 2.18.0    |
+| ghcr.io/coreweave/nccl-tests:12.0.1-cudnn8-devel-ubuntu20.04-nccl2.19.3-1-868dc3d | 20.04      | 12.0.1   | 2.19.3   | 2.18.0    |
+| ghcr.io/coreweave/nccl-tests:11.8.0-cudnn8-devel-ubuntu20.04-nccl2.16.5-1-868dc3d | 20.04      | 11.8.0   | 2.16.5   | 2.14.0    |
 | ghcr.io/coreweave/nccl-tests:11.7.1-cudnn8-devel-ubuntu20.04-nccl2.14.3-1-a6a61ab | 20.04      | 11.7.1   | 2.14.3   | 2.14.0    |
-| ghcr.io/coreweave/nccl-tests:12.3.1-devel-ubuntu22.04-nccl2.19.3-1-a72ab6c        | 22.04      | 12.3.1   | 2.19.3   | 2.17.0    |
-| ghcr.io/coreweave/nccl-tests:12.2.2-cudnn8-devel-ubuntu22.04-nccl2.19.3-1-a72ab6c | 22.04      | 12.2.2   | 2.19.3   | 2.17.0    |
-| ghcr.io/coreweave/nccl-tests:12.1.1-cudnn8-devel-ubuntu22.04-nccl2.18.3-1-a72ab6c | 22.04      | 12.1.1   | 2.18.3   | 2.17.0    |
-| ghcr.io/coreweave/nccl-tests:12.0.1-cudnn8-devel-ubuntu22.04-nccl2.18.5-1-a72ab6c | 22.04      | 12.0.1   | 2.18.5   | 2.17.0    |
+| ghcr.io/coreweave/nccl-tests:12.3.2-cudnn9-devel-ubuntu22.04-nccl2.20.3-1-868dc3d | 22.04      | 12.3.2   | 2.20.3   | 2.18.0    |
+| ghcr.io/coreweave/nccl-tests:12.2.2-cudnn8-devel-ubuntu22.04-nccl2.19.3-1-868dc3d | 22.04      | 12.2.2   | 2.19.3   | 2.18.0    |
+| ghcr.io/coreweave/nccl-tests:12.1.1-cudnn8-devel-ubuntu22.04-nccl2.18.3-1-868dc3d | 22.04      | 12.1.1   | 2.18.3   | 2.18.0    |
+| ghcr.io/coreweave/nccl-tests:12.0.1-cudnn8-devel-ubuntu22.04-nccl2.18.5-1-868dc3d | 22.04      | 12.0.1   | 2.18.5   | 2.18.0    |
 | coreweave/nccl-tests:2022-09-28_16-34-19.392_EDT                                  | 20.04      | 11.6.2   | 2.12.10  | 2.11      |
 
 ## Running NCCL Tests


### PR DESCRIPTION
# Update image tags for #31

This change updates the image tags in the README with the changes made in #31, including version updates and a new CUDA 12.3 × Ubuntu 20.04 image.