### PR TITLE
feat: Add CUDA 12.4 builds, update NCCL

### DIFF
--- a/.github/workflows/ubuntu-20.yml
+++ b/.github/workflows/ubuntu-20.yml
@@ -55,7 +55,7 @@ jobs:
       base-tag: 12.2.2-cudnn8-devel-ubuntu20.04
       cuda-version-minor: "12.2.2"
       cuda-version-major: "12.2"
-      nccl-version: 2.20.3-1
+      nccl-version: 2.21.5-1
       cuda-samples-version: "12.2"
       hpcx-distribution: "hpcx-v2.18-gcc-mlnx_ofed-ubuntu20.04-cuda12-x86_64"
 
@@ -70,4 +70,17 @@ jobs:
       cuda-version-major: "12.3"
       nccl-version: 2.20.3-1
       cuda-samples-version: "12.3"
+      hpcx-distribution: "hpcx-v2.18-gcc-mlnx_ofed-ubuntu20.04-cuda12-x86_64"
+
+  cu124:
+    uses: ./.github/workflows/build.yml
+    with:
+      folder: .
+      dockerfile: Dockerfile.ubuntu20
+      base-image: nvidia/cuda
+      base-tag: 12.4.0-devel-ubuntu20.04
+      cuda-version-minor: "12.4.0"
+      cuda-version-major: "12.4"
+      nccl-version: 2.21.5-1
+      cuda-samples-version: "12.4"
       hpcx-distribution: "hpcx-v2.18-gcc-mlnx_ofed-ubuntu20.04-cuda12-x86_64"

--- a/.github/workflows/ubuntu-22.yml
+++ b/.github/workflows/ubuntu-22.yml
@@ -58,3 +58,16 @@ jobs:
       nccl-version: 2.20.3-1
       cuda-samples-version: "12.3"
       hpcx-distribution: "hpcx-v2.18-gcc-mlnx_ofed-ubuntu22.04-cuda12-x86_64"
+
+  cu124:
+    uses: ./.github/workflows/build.yml
+    with:
+      folder: .
+      dockerfile: Dockerfile.ubuntu22
+      base-image: nvidia/cuda
+      base-tag: 12.4.0-devel-ubuntu22.04
+      cuda-version-minor: "12.4.0"
+      cuda-version-major: "12.4"
+      nccl-version: 2.21.5-1
+      cuda-samples-version: "12.4"
+      hpcx-distribution: "hpcx-v2.18-gcc-mlnx_ofed-ubuntu22.04-cuda12-x86_64"


### PR DESCRIPTION
# Add CUDA 12.4, NCCL v2.21.5

This change adds CUDA 12.4 builds for Ubuntu 20.04 & 22.04, using NCCL v2.21.5. It also updates the Ubuntu 20.04 CUDA 12.2.2 build to use NCCL v2.21.5, up from v2.20.3.