### PR TITLE
feat: Update HPC-X to v2.19

### DIFF
--- a/.github/workflows/ubuntu-20.yml
+++ b/.github/workflows/ubuntu-20.yml
@@ -31,7 +31,7 @@ jobs:
       cuda-version-major: "12.0"
       nccl-version: 2.19.3-1
       cuda-samples-version: "12.0"
-      hpcx-distribution: "hpcx-v2.18-gcc-mlnx_ofed-ubuntu20.04-cuda12-x86_64"
+      hpcx-distribution: "hpcx-v2.19-gcc-mlnx_ofed-ubuntu20.04-cuda12-x86_64"
 
   cu121:
     uses: ./.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
       cuda-version-major: "12.1"
       nccl-version: 2.18.3-1
       cuda-samples-version: "12.1"
-      hpcx-distribution: "hpcx-v2.18-gcc-mlnx_ofed-ubuntu20.04-cuda12-x86_64"
+      hpcx-distribution: "hpcx-v2.19-gcc-mlnx_ofed-ubuntu20.04-cuda12-x86_64"
 
   cu122:
     uses: ./.github/workflows/build.yml
@@ -57,7 +57,7 @@ jobs:
       cuda-version-major: "12.2"
       nccl-version: 2.21.5-1
       cuda-samples-version: "12.2"
-      hpcx-distribution: "hpcx-v2.18-gcc-mlnx_ofed-ubuntu20.04-cuda12-x86_64"
+      hpcx-distribution: "hpcx-v2.19-gcc-mlnx_ofed-ubuntu20.04-cuda12-x86_64"
 
   cu123:
     uses: ./.github/workflows/build.yml
@@ -70,7 +70,7 @@ jobs:
       cuda-version-major: "12.3"
       nccl-version: 2.20.3-1
       cuda-samples-version: "12.3"
-      hpcx-distribution: "hpcx-v2.18-gcc-mlnx_ofed-ubuntu20.04-cuda12-x86_64"
+      hpcx-distribution: "hpcx-v2.19-gcc-mlnx_ofed-ubuntu20.04-cuda12-x86_64"
 
   cu124:
     uses: ./.github/workflows/build.yml
@@ -83,4 +83,4 @@ jobs:
       cuda-version-major: "12.4"
       nccl-version: 2.21.5-1
       cuda-samples-version: "12.4"
-      hpcx-distribution: "hpcx-v2.18-gcc-mlnx_ofed-ubuntu20.04-cuda12-x86_64"
+      hpcx-distribution: "hpcx-v2.19-gcc-mlnx_ofed-ubuntu20.04-cuda12-x86_64"

--- a/.github/workflows/ubuntu-22.yml
+++ b/.github/workflows/ubuntu-22.yml
@@ -18,7 +18,7 @@ jobs:
       cuda-version-major: "12.0"
       nccl-version: 2.18.5-1
       cuda-samples-version: "12.0"
-      hpcx-distribution: "hpcx-v2.18-gcc-mlnx_ofed-ubuntu22.04-cuda12-x86_64"
+      hpcx-distribution: "hpcx-v2.19-gcc-mlnx_ofed-ubuntu22.04-cuda12-x86_64"
 
   cu121:
     uses: ./.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
       cuda-version-major: "12.1"
       nccl-version: 2.18.3-1
       cuda-samples-version: "12.1"
-      hpcx-distribution: "hpcx-v2.18-gcc-mlnx_ofed-ubuntu22.04-cuda12-x86_64"
+      hpcx-distribution: "hpcx-v2.19-gcc-mlnx_ofed-ubuntu22.04-cuda12-x86_64"
 
   cu122:
     uses: ./.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
       cuda-version-major: "12.2"
       nccl-version: 2.19.3-1
       cuda-samples-version: "12.2"
-      hpcx-distribution: "hpcx-v2.18-gcc-mlnx_ofed-ubuntu22.04-cuda12-x86_64"
+      hpcx-distribution: "hpcx-v2.19-gcc-mlnx_ofed-ubuntu22.04-cuda12-x86_64"
 
   cu123:
     uses: ./.github/workflows/build.yml
@@ -57,7 +57,7 @@ jobs:
       cuda-version-major: "12.3"
       nccl-version: 2.20.3-1
       cuda-samples-version: "12.3"
-      hpcx-distribution: "hpcx-v2.18-gcc-mlnx_ofed-ubuntu22.04-cuda12-x86_64"
+      hpcx-distribution: "hpcx-v2.19-gcc-mlnx_ofed-ubuntu22.04-cuda12-x86_64"
 
   cu124:
     uses: ./.github/workflows/build.yml
@@ -70,4 +70,4 @@ jobs:
       cuda-version-major: "12.4"
       nccl-version: 2.21.5-1
       cuda-samples-version: "12.4"
-      hpcx-distribution: "hpcx-v2.18-gcc-mlnx_ofed-ubuntu22.04-cuda12-x86_64"
+      hpcx-distribution: "hpcx-v2.19-gcc-mlnx_ofed-ubuntu22.04-cuda12-x86_64"

--- a/README.md
+++ b/README.md
@@ -52,18 +52,18 @@ built from these Dockerfiles that can be used as base for your own images.
 
 | **Image Tag**                                                                     | **Ubuntu** | **CUDA** | **NCCL** | **HPC-X** |
 |-----------------------------------------------------------------------------------|------------|----------|----------|-----------|
-| ghcr.io/coreweave/nccl-tests:12.4.1-cudnn-devel-ubuntu20.04-nccl2.21.5-1-027b52a  | 20.04      | 12.4.1   | 2.21.5   | 2.18.0    |
-| ghcr.io/coreweave/nccl-tests:12.3.2-cudnn9-devel-ubuntu20.04-nccl2.20.3-1-868dc3d | 20.04      | 12.3.2   | 2.20.3   | 2.18.0    |
-| ghcr.io/coreweave/nccl-tests:12.2.2-cudnn8-devel-ubuntu20.04-nccl2.21.5-1-027b52a | 20.04      | 12.2.2   | 2.21.5   | 2.18.0    |
-| ghcr.io/coreweave/nccl-tests:12.1.1-cudnn8-devel-ubuntu20.04-nccl2.18.3-1-868dc3d | 20.04      | 12.1.1   | 2.18.3   | 2.18.0    |
-| ghcr.io/coreweave/nccl-tests:12.0.1-cudnn8-devel-ubuntu20.04-nccl2.19.3-1-868dc3d | 20.04      | 12.0.1   | 2.19.3   | 2.18.0    |
+| ghcr.io/coreweave/nccl-tests:12.4.1-cudnn-devel-ubuntu20.04-nccl2.21.5-1-85f9143  | 20.04      | 12.4.1   | 2.21.5   | 2.19.0    |
+| ghcr.io/coreweave/nccl-tests:12.3.2-cudnn9-devel-ubuntu20.04-nccl2.20.3-1-85f9143 | 20.04      | 12.3.2   | 2.20.3   | 2.19.0    |
+| ghcr.io/coreweave/nccl-tests:12.2.2-cudnn8-devel-ubuntu20.04-nccl2.21.5-1-85f9143 | 20.04      | 12.2.2   | 2.21.5   | 2.19.0    |
+| ghcr.io/coreweave/nccl-tests:12.1.1-cudnn8-devel-ubuntu20.04-nccl2.18.3-1-85f9143 | 20.04      | 12.1.1   | 2.18.3   | 2.19.0    |
+| ghcr.io/coreweave/nccl-tests:12.0.1-cudnn8-devel-ubuntu20.04-nccl2.19.3-1-85f9143 | 20.04      | 12.0.1   | 2.19.3   | 2.19.0    |
 | ghcr.io/coreweave/nccl-tests:11.8.0-cudnn8-devel-ubuntu20.04-nccl2.16.5-1-868dc3d | 20.04      | 11.8.0   | 2.16.5   | 2.14.0    |
 | ghcr.io/coreweave/nccl-tests:11.7.1-cudnn8-devel-ubuntu20.04-nccl2.14.3-1-a6a61ab | 20.04      | 11.7.1   | 2.14.3   | 2.14.0    |
-| ghcr.io/coreweave/nccl-tests:12.4.1-cudnn-devel-ubuntu22.04-nccl2.21.5-1-027b52a  | 22.04      | 12.4.1   | 2.21.5   | 2.18.0    |
-| ghcr.io/coreweave/nccl-tests:12.3.2-cudnn9-devel-ubuntu22.04-nccl2.20.3-1-868dc3d | 22.04      | 12.3.2   | 2.20.3   | 2.18.0    |
-| ghcr.io/coreweave/nccl-tests:12.2.2-cudnn8-devel-ubuntu22.04-nccl2.19.3-1-868dc3d | 22.04      | 12.2.2   | 2.19.3   | 2.18.0    |
-| ghcr.io/coreweave/nccl-tests:12.1.1-cudnn8-devel-ubuntu22.04-nccl2.18.3-1-868dc3d | 22.04      | 12.1.1   | 2.18.3   | 2.18.0    |
-| ghcr.io/coreweave/nccl-tests:12.0.1-cudnn8-devel-ubuntu22.04-nccl2.18.5-1-868dc3d | 22.04      | 12.0.1   | 2.18.5   | 2.18.0    |
+| ghcr.io/coreweave/nccl-tests:12.4.1-cudnn-devel-ubuntu22.04-nccl2.21.5-1-85f9143  | 22.04      | 12.4.1   | 2.21.5   | 2.19.0    |
+| ghcr.io/coreweave/nccl-tests:12.3.2-cudnn9-devel-ubuntu22.04-nccl2.20.3-1-85f9143 | 22.04      | 12.3.2   | 2.20.3   | 2.19.0    |
+| ghcr.io/coreweave/nccl-tests:12.2.2-cudnn8-devel-ubuntu22.04-nccl2.19.3-1-85f9143 | 22.04      | 12.2.2   | 2.19.3   | 2.19.0    |
+| ghcr.io/coreweave/nccl-tests:12.1.1-cudnn8-devel-ubuntu22.04-nccl2.18.3-1-85f9143 | 22.04      | 12.1.1   | 2.18.3   | 2.19.0    |
+| ghcr.io/coreweave/nccl-tests:12.0.1-cudnn8-devel-ubuntu22.04-nccl2.18.5-1-85f9143 | 22.04      | 12.0.1   | 2.18.5   | 2.19.0    |
 | coreweave/nccl-tests:2022-09-28_16-34-19.392_EDT                                  | 20.04      | 11.6.2   | 2.12.10  | 2.11      |
 
 ## Running NCCL Tests


### PR DESCRIPTION
# HPC-X v2.19

This change updates the version of HPC-X in all CUDA 12 image builds to v2.19, up from v2.18.

> [!NOTE]
> The release notes and documentation for the v2.19 release of HPC-X are available on NVIDIA's site:
> [**NVIDIA HPC-X Software Toolkit Rev 2.19.0**](https://docs.nvidia.com/networking/display/hpcxv219)