### PR TITLE
feat: Add CUDA 12.6 builds, update HPC-X & NCCL

### DIFF
--- a/.github/workflows/ubuntu-20.yml
+++ b/.github/workflows/ubuntu-20.yml
@@ -84,3 +84,16 @@ jobs:
       nccl-version: 2.21.5-1
       cuda-samples-version: "12.4"
       hpcx-distribution: "hpcx-v2.19-gcc-mlnx_ofed-ubuntu20.04-cuda12-x86_64"
+
+  cu126:
+    uses: ./.github/workflows/build.yml
+    with:
+      folder: .
+      dockerfile: Dockerfile.ubuntu20
+      base-image: nvidia/cuda
+      base-tag: 12.6.1-cudnn-devel-ubuntu20.04
+      cuda-version-minor: "12.6.1"
+      cuda-version-major: "12.6"
+      nccl-version: 2.21.5-1
+      cuda-samples-version: "12.5"
+      hpcx-distribution: "hpcx-v2.19-gcc-mlnx_ofed-ubuntu20.04-cuda12-x86_64"

--- a/.github/workflows/ubuntu-20.yml
+++ b/.github/workflows/ubuntu-20.yml
@@ -31,20 +31,7 @@ jobs:
       cuda-version-major: "12.0"
       nccl-version: 2.19.3-1
       cuda-samples-version: "12.0"
-      hpcx-distribution: "hpcx-v2.19-gcc-mlnx_ofed-ubuntu20.04-cuda12-x86_64"
-
-  cu121:
-    uses: ./.github/workflows/build.yml
-    with:
-      folder: .
-      dockerfile: Dockerfile.ubuntu20
-      base-image: nvidia/cuda
-      base-tag: 12.1.1-cudnn8-devel-ubuntu20.04
-      cuda-version-minor: "12.1.1"
-      cuda-version-major: "12.1"
-      nccl-version: 2.18.3-1
-      cuda-samples-version: "12.1"
-      hpcx-distribution: "hpcx-v2.19-gcc-mlnx_ofed-ubuntu20.04-cuda12-x86_64"
+      hpcx-distribution: "hpcx-v2.20-gcc-mlnx_ofed-ubuntu20.04-cuda12-x86_64"
 
   cu122:
     uses: ./.github/workflows/build.yml
@@ -57,20 +44,7 @@ jobs:
       cuda-version-major: "12.2"
       nccl-version: 2.21.5-1
       cuda-samples-version: "12.2"
-      hpcx-distribution: "hpcx-v2.19-gcc-mlnx_ofed-ubuntu20.04-cuda12-x86_64"
-
-  cu123:
-    uses: ./.github/workflows/build.yml
-    with:
-      folder: .
-      dockerfile: Dockerfile.ubuntu20
-      base-image: nvidia/cuda
-      base-tag: 12.3.2-cudnn9-devel-ubuntu20.04
-      cuda-version-minor: "12.3.2"
-      cuda-version-major: "12.3"
-      nccl-version: 2.20.3-1
-      cuda-samples-version: "12.3"
-      hpcx-distribution: "hpcx-v2.19-gcc-mlnx_ofed-ubuntu20.04-cuda12-x86_64"
+      hpcx-distribution: "hpcx-v2.20-gcc-mlnx_ofed-ubuntu20.04-cuda12-x86_64"
 
   cu124:
     uses: ./.github/workflows/build.yml
@@ -81,9 +55,9 @@ jobs:
       base-tag: 12.4.1-cudnn-devel-ubuntu20.04
       cuda-version-minor: "12.4.1"
       cuda-version-major: "12.4"
-      nccl-version: 2.21.5-1
+      nccl-version: 2.23.4-1
       cuda-samples-version: "12.4"
-      hpcx-distribution: "hpcx-v2.19-gcc-mlnx_ofed-ubuntu20.04-cuda12-x86_64"
+      hpcx-distribution: "hpcx-v2.20-gcc-mlnx_ofed-ubuntu20.04-cuda12-x86_64"
 
   cu126:
     uses: ./.github/workflows/build.yml
@@ -94,6 +68,6 @@ jobs:
       base-tag: 12.6.1-cudnn-devel-ubuntu20.04
       cuda-version-minor: "12.6.1"
       cuda-version-major: "12.6"
-      nccl-version: 2.21.5-1
+      nccl-version: 2.23.4-1
       cuda-samples-version: "12.5"
-      hpcx-distribution: "hpcx-v2.19-gcc-mlnx_ofed-ubuntu20.04-cuda12-x86_64"
+      hpcx-distribution: "hpcx-v2.20-gcc-mlnx_ofed-ubuntu20.04-cuda12-x86_64"

--- a/.github/workflows/ubuntu-22.yml
+++ b/.github/workflows/ubuntu-22.yml
@@ -18,20 +18,7 @@ jobs:
       cuda-version-major: "12.0"
       nccl-version: 2.18.5-1
       cuda-samples-version: "12.0"
-      hpcx-distribution: "hpcx-v2.19-gcc-mlnx_ofed-ubuntu22.04-cuda12-x86_64"
-
-  cu121:
-    uses: ./.github/workflows/build.yml
-    with:
-      folder: .
-      dockerfile: Dockerfile.ubuntu22
-      base-image: nvidia/cuda
-      base-tag: 12.1.1-cudnn8-devel-ubuntu22.04
-      cuda-version-minor: "12.1.1"
-      cuda-version-major: "12.1"
-      nccl-version: 2.18.3-1
-      cuda-samples-version: "12.1"
-      hpcx-distribution: "hpcx-v2.19-gcc-mlnx_ofed-ubuntu22.04-cuda12-x86_64"
+      hpcx-distribution: "hpcx-v2.20-gcc-mlnx_ofed-ubuntu22.04-cuda12-x86_64"
 
   cu122:
     uses: ./.github/workflows/build.yml
@@ -42,22 +29,9 @@ jobs:
       base-tag: 12.2.2-cudnn8-devel-ubuntu22.04
       cuda-version-minor: "12.2.2"
       cuda-version-major: "12.2"
-      nccl-version: 2.19.3-1
+      nccl-version: 2.23.4-1
       cuda-samples-version: "12.2"
-      hpcx-distribution: "hpcx-v2.19-gcc-mlnx_ofed-ubuntu22.04-cuda12-x86_64"
-
-  cu123:
-    uses: ./.github/workflows/build.yml
-    with:
-      folder: .
-      dockerfile: Dockerfile.ubuntu22
-      base-image: nvidia/cuda
-      base-tag: 12.3.2-cudnn9-devel-ubuntu22.04
-      cuda-version-minor: "12.3.2"
-      cuda-version-major: "12.3"
-      nccl-version: 2.20.3-1
-      cuda-samples-version: "12.3"
-      hpcx-distribution: "hpcx-v2.19-gcc-mlnx_ofed-ubuntu22.04-cuda12-x86_64"
+      hpcx-distribution: "hpcx-v2.20-gcc-mlnx_ofed-ubuntu22.04-cuda12-x86_64"
 
   cu124:
     uses: ./.github/workflows/build.yml
@@ -68,9 +42,9 @@ jobs:
       base-tag: 12.4.1-cudnn-devel-ubuntu22.04
       cuda-version-minor: "12.4.1"
       cuda-version-major: "12.4"
-      nccl-version: 2.21.5-1
+      nccl-version: 2.23.4-1
       cuda-samples-version: "12.4"
-      hpcx-distribution: "hpcx-v2.19-gcc-mlnx_ofed-ubuntu22.04-cuda12-x86_64"
+      hpcx-distribution: "hpcx-v2.20-gcc-mlnx_ofed-ubuntu22.04-cuda12-x86_64"
 
   cu126:
     uses: ./.github/workflows/build.yml
@@ -81,6 +55,6 @@ jobs:
       base-tag: 12.6.1-cudnn-devel-ubuntu22.04
       cuda-version-minor: "12.6.1"
       cuda-version-major: "12.6"
-      nccl-version: 2.21.5-1
+      nccl-version: 2.23.4-1
       cuda-samples-version: "12.5"
-      hpcx-distribution: "hpcx-v2.19-gcc-mlnx_ofed-ubuntu22.04-cuda12-x86_64"
+      hpcx-distribution: "hpcx-v2.20-gcc-mlnx_ofed-ubuntu22.04-cuda12-x86_64"

--- a/.github/workflows/ubuntu-22.yml
+++ b/.github/workflows/ubuntu-22.yml
@@ -71,3 +71,16 @@ jobs:
       nccl-version: 2.21.5-1
       cuda-samples-version: "12.4"
       hpcx-distribution: "hpcx-v2.19-gcc-mlnx_ofed-ubuntu22.04-cuda12-x86_64"
+
+  cu126:
+    uses: ./.github/workflows/build.yml
+    with:
+      folder: .
+      dockerfile: Dockerfile.ubuntu22
+      base-image: nvidia/cuda
+      base-tag: 12.6.1-cudnn-devel-ubuntu22.04
+      cuda-version-minor: "12.6.1"
+      cuda-version-major: "12.6"
+      nccl-version: 2.21.5-1
+      cuda-samples-version: "12.5"
+      hpcx-distribution: "hpcx-v2.19-gcc-mlnx_ofed-ubuntu22.04-cuda12-x86_64"

--- a/Dockerfile.ubuntu22
+++ b/Dockerfile.ubuntu22
@@ -165,7 +165,7 @@ RUN cd /opt/hpcx/sources/ && rm -r /opt/hpcx/ompi && tar -zxvf openmpi-gitclone.
            --with-hcoll=/opt/hpcx/hcoll --with-ucx=/opt/hpcx/ucx \
            --with-platform=contrib/platform/mellanox/optimized \
            --with-slurm --with-hwloc --with-libevent \
-           --with-pmix=/usr/lib/x86_64-linux-gnu/pmix2 \
+           --with-pmix="/usr/lib/$(gcc -print-multiarch)/pmix2" \
            --without-xpmem --with-cuda --with-ucc=/opt/hpcx/ucc && \
            make -j20 && \
            make -j20 install && \

--- a/README.md
+++ b/README.md
@@ -52,19 +52,15 @@ built from these Dockerfiles that can be used as base for your own images.
 
 | **Image Tag**                                                                     | **Ubuntu** | **CUDA** | **NCCL** | **HPC-X** |
 |-----------------------------------------------------------------------------------|------------|----------|----------|-----------|
-| ghcr.io/coreweave/nccl-tests:12.4.1-cudnn-devel-ubuntu20.04-nccl2.21.5-1-85f9143  | 20.04      | 12.4.1   | 2.21.5   | 2.19.0    |
-| ghcr.io/coreweave/nccl-tests:12.3.2-cudnn9-devel-ubuntu20.04-nccl2.20.3-1-85f9143 | 20.04      | 12.3.2   | 2.20.3   | 2.19.0    |
-| ghcr.io/coreweave/nccl-tests:12.2.2-cudnn8-devel-ubuntu20.04-nccl2.21.5-1-85f9143 | 20.04      | 12.2.2   | 2.21.5   | 2.19.0    |
-| ghcr.io/coreweave/nccl-tests:12.1.1-cudnn8-devel-ubuntu20.04-nccl2.18.3-1-85f9143 | 20.04      | 12.1.1   | 2.18.3   | 2.19.0    |
-| ghcr.io/coreweave/nccl-tests:12.0.1-cudnn8-devel-ubuntu20.04-nccl2.19.3-1-85f9143 | 20.04      | 12.0.1   | 2.19.3   | 2.19.0    |
+| ghcr.io/coreweave/nccl-tests:12.6.1-cudnn-devel-ubuntu20.04-nccl2.23.4-1-2ff05b2  | 20.04      | 12.6.1   | 2.23.4   | 2.20.0    |
+| ghcr.io/coreweave/nccl-tests:12.4.1-cudnn-devel-ubuntu20.04-nccl2.23.4-1-2ff05b2  | 20.04      | 12.4.1   | 2.23.4   | 2.20.0    |
+| ghcr.io/coreweave/nccl-tests:12.2.2-cudnn8-devel-ubuntu20.04-nccl2.21.5-1-2ff05b2 | 20.04      | 12.2.2   | 2.21.5   | 2.20.0    |
+| ghcr.io/coreweave/nccl-tests:12.0.1-cudnn8-devel-ubuntu20.04-nccl2.19.3-1-2ff05b2 | 20.04      | 12.0.1   | 2.19.3   | 2.20.0    |
 | ghcr.io/coreweave/nccl-tests:11.8.0-cudnn8-devel-ubuntu20.04-nccl2.16.5-1-868dc3d | 20.04      | 11.8.0   | 2.16.5   | 2.14.0    |
-| ghcr.io/coreweave/nccl-tests:11.7.1-cudnn8-devel-ubuntu20.04-nccl2.14.3-1-a6a61ab | 20.04      | 11.7.1   | 2.14.3   | 2.14.0    |
-| ghcr.io/coreweave/nccl-tests:12.4.1-cudnn-devel-ubuntu22.04-nccl2.21.5-1-85f9143  | 22.04      | 12.4.1   | 2.21.5   | 2.19.0    |
-| ghcr.io/coreweave/nccl-tests:12.3.2-cudnn9-devel-ubuntu22.04-nccl2.20.3-1-85f9143 | 22.04      | 12.3.2   | 2.20.3   | 2.19.0    |
-| ghcr.io/coreweave/nccl-tests:12.2.2-cudnn8-devel-ubuntu22.04-nccl2.19.3-1-85f9143 | 22.04      | 12.2.2   | 2.19.3   | 2.19.0    |
-| ghcr.io/coreweave/nccl-tests:12.1.1-cudnn8-devel-ubuntu22.04-nccl2.18.3-1-85f9143 | 22.04      | 12.1.1   | 2.18.3   | 2.19.0    |
-| ghcr.io/coreweave/nccl-tests:12.0.1-cudnn8-devel-ubuntu22.04-nccl2.18.5-1-85f9143 | 22.04      | 12.0.1   | 2.18.5   | 2.19.0    |
-| coreweave/nccl-tests:2022-09-28_16-34-19.392_EDT                                  | 20.04      | 11.6.2   | 2.12.10  | 2.11      |
+| ghcr.io/coreweave/nccl-tests:12.6.1-cudnn-devel-ubuntu22.04-nccl2.23.4-1-2ff05b2  | 22.04      | 12.6.1   | 2.23.4   | 2.20.0    |
+| ghcr.io/coreweave/nccl-tests:12.4.1-cudnn-devel-ubuntu22.04-nccl2.23.4-1-2ff05b2  | 22.04      | 12.4.1   | 2.23.4   | 2.20.0    |
+| ghcr.io/coreweave/nccl-tests:12.2.2-cudnn8-devel-ubuntu22.04-nccl2.23.4-1-2ff05b2 | 22.04      | 12.2.2   | 2.23.4   | 2.20.0    |
+| ghcr.io/coreweave/nccl-tests:12.0.1-cudnn8-devel-ubuntu22.04-nccl2.18.5-1-2ff05b2 | 22.04      | 12.0.1   | 2.18.5   | 2.20.0    |
 
 ## Running NCCL Tests
 


### PR DESCRIPTION
# CUDA 12.6, HPC-X 2.20, & NCCL Updates

This change adds a build for CUDA 12.6 on Ubuntu 22.04 and 20.04. It also updates HPC-X to version 2.20 on all CUDA 12.x builds, and updates NCCL to the latest version available for each build, up to 2.23.4-1.

It additionally removes older odd-numbered builds for CUDA 12.1 and CUDA 12.3, which no longer receive updated NCCL builds from NVIDIA, and removes unsupported image tags from the README. (If CUDA 12.3 is still desired, we can add it back.)

The supported image tags after this change would be 12.0, 12.2, 12.4, and 12.6 on Ubuntu 22.04 and 20.04, as well as 11.8 only on Ubuntu 20.04.

This additionally includes a change for cross-arch build pipeline compatibility while building OpenMPI.