### PR TITLE
feat(slurm): Add a GB200 NVL72 example

### DIFF
--- a/slurm/nccl-test-distributed-gb200-nvl72-enroot.slurm
+++ b/slurm/nccl-test-distributed-gb200-nvl72-enroot.slurm
@@ -1,0 +1,33 @@
+#!/bin/bash
+###
+#SBATCH --job-name=nccl_test
+#SBATCH --nodes=18
+#SBATCH --ntasks-per-node=4
+#SBATCH --gpus-per-node=4
+#SBATCH --time=20:00
+#SBATCH --output="%x_%j.out"
+#SBATCH --exclusive
+
+# NCCL environment variables are documented at:
+# https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/env.html
+
+export NCCL_SOCKET_IFNAME=eth0
+export NCCL_IB_HCA=ibp
+export UCX_NET_DEVICES=ibp0:1,ibp1:1,ibp2:1,ibp3:1
+export SHARP_COLL_ENABLE_PCI_RELAXED_ORDERING=1
+export NCCL_COLLNET_ENABLE=0
+
+export NVIDIA_IMEX_CHANNELS=0
+export NCCL_NVLS_ENABLE=1
+
+export PMIX_MCA_gds='^ds12'
+
+# Log the assigned nodes
+echo "Using nodes: $SLURM_JOB_NODELIST"
+
+# Save the container to a NFS mount for speed ups on large jobs
+# --container-save=/mnt/home/user/nccl-tests.sqsh -> --container-image=/mnt/home/user/nccl-tests.sqsh
+
+srun --container-image=ghcr.io#coreweave/nccl-tests:12.8.0-devel-ubuntu22.04-nccl2.25.1-1-57fa979 \
+     --mpi=pmix --no-container-remap-root --container-mount-home \
+     /opt/nccl_tests/build/all_reduce_perf -b 512M -e 8G -f 2 -g 1


### PR DESCRIPTION
Example output for a full nvl72 rack run:
```text
#  Rank 71 Group  0 Pid  14840 on slurm-gb200-207-171 device  3 [0x01] NVIDIA Graphics Device
#
#                                                              out-of-place                       in-place          
#       size         count      type   redop    root     time   algbw   busbw #wrong     time   algbw   busbw #wrong
#        (B)    (elements)                               (us)  (GB/s)  (GB/s)            (us)  (GB/s)  (GB/s)       
   536870912     134217728     float     sum      -1   1806.7  297.16  586.06      0   1835.9  292.43  576.74      0
  1073741824     268435456     float     sum      -1   3108.8  345.38  681.17      0   2924.7  367.13  724.06      0
  2147483648     536870912     float     sum      -1   5589.1  384.22  757.78      0   5474.6  392.26  773.62      0
  4294967296    1073741824     float     sum      -1    10094  425.49  839.16      0    10141  423.54  835.32      0
  8589934592    2147483648     float     sum      -1    20299  423.16  834.57      0    20006  429.37  846.82      0
# Out of bounds values : 0 OK
# Avg bus bandwidth    : 745.53 
```

Example performance for a multi-rack NVL72 run:
```text
#  Rank 143 Group  0 Pid  14840 on slurm-gb200-207-171 device  3 [0x01] NVIDIA Graphics Device
#
#                                                              out-of-place                       in-place          
#       size         count      type   redop    root     time   algbw   busbw #wrong     time   algbw   busbw #wrong
#        (B)    (elements)                               (us)  (GB/s)  (GB/s)            (us)  (GB/s)  (GB/s)       
   536870912     134217728     float     sum      -1   2156.8  248.92  493.94      0   2093.7  256.42  508.83      0
  1073741824     268435456     float     sum      -1   3574.4  300.40  596.10      0   3565.5  301.15  597.59      0
  2147483648     536870912     float     sum      -1   6264.0  342.83  680.30      0   6258.4  343.14  680.91      0
  4294967296    1073741824     float     sum      -1    11469  374.47  743.09      0    11435  375.61  745.36      0
  8589934592    2147483648     float     sum      -1    21493  399.65  793.06      0    21525  399.06  791.88      0
 17179869184    4294967296     float     sum      -1    42067  408.40  810.41      0    41557  413.41  820.36      0
# Out of bounds values : 0 OK
# Avg bus bandwidth    : 688.487 
```