### PR TITLE
feat: Update to CUDA 12.8.1, NCCL 2.26.2, HPC-X 2.22.1, and cuDNN 9.8.0

### DIFF
--- a/.github/workflows/ubuntu-20.yml
+++ b/.github/workflows/ubuntu-20.yml
@@ -21,9 +21,9 @@ jobs:
       base-image: nvidia/cuda
       base-tag: 12.2.2-devel-ubuntu20.04
       cuda-version: "12.2.2"
-      nccl-version: 2.25.1-1
+      nccl-version: 2.26.2-1
       cuda-samples-version: "12.2"
-      hpcx-distribution: "hpcx-v2.22-gcc-doca_ofed-ubuntu20.04-cuda12"
+      hpcx-distribution: "hpcx-v2.22.1-gcc-doca_ofed-ubuntu20.04-cuda12"
 
   cu124:
     uses: ./.github/workflows/build.yml
@@ -39,9 +39,9 @@ jobs:
       base-image: nvidia/cuda
       base-tag: 12.4.1-devel-ubuntu20.04
       cuda-version: "12.4.1"
-      nccl-version: 2.25.1-1
+      nccl-version: 2.26.2-1
       cuda-samples-version: "12.4"
-      hpcx-distribution: "hpcx-v2.22-gcc-doca_ofed-ubuntu20.04-cuda12"
+      hpcx-distribution: "hpcx-v2.22.1-gcc-doca_ofed-ubuntu20.04-cuda12"
 
   cu126:
     uses: ./.github/workflows/build.yml
@@ -57,9 +57,9 @@ jobs:
       base-image: nvidia/cuda
       base-tag: 12.6.3-devel-ubuntu20.04
       cuda-version: "12.6.3"
-      nccl-version: 2.25.1-1
+      nccl-version: 2.26.2-1
       cuda-samples-version: "12.5"
-      hpcx-distribution: "hpcx-v2.22-gcc-doca_ofed-ubuntu20.04-cuda12"
+      hpcx-distribution: "hpcx-v2.22.1-gcc-doca_ofed-ubuntu20.04-cuda12"
 
   cu128:
     uses: ./.github/workflows/build.yml
@@ -73,8 +73,8 @@ jobs:
       folder: .
       dockerfile: Dockerfile.ubuntu20
       base-image: nvidia/cuda
-      base-tag: 12.8.0-devel-ubuntu20.04
-      cuda-version: "12.8.0"
-      nccl-version: 2.25.1-1
+      base-tag: 12.8.1-devel-ubuntu20.04
+      cuda-version: "12.8.1"
+      nccl-version: 2.26.2-1
       cuda-samples-version: "12.5"
-      hpcx-distribution: "hpcx-v2.22-gcc-doca_ofed-ubuntu20.04-cuda12"
+      hpcx-distribution: "hpcx-v2.22.1-gcc-doca_ofed-ubuntu20.04-cuda12"

--- a/.github/workflows/ubuntu-22.yml
+++ b/.github/workflows/ubuntu-22.yml
@@ -21,9 +21,9 @@ jobs:
       base-image: nvidia/cuda
       base-tag: 12.2.2-devel-ubuntu22.04
       cuda-version: "12.2.2"
-      nccl-version: 2.25.1-1
+      nccl-version: 2.26.2-1
       cuda-samples-version: "12.2"
-      hpcx-distribution: "hpcx-v2.22-gcc-doca_ofed-ubuntu22.04-cuda12"
+      hpcx-distribution: "hpcx-v2.22.1-gcc-doca_ofed-ubuntu22.04-cuda12"
 
   cu124:
     uses: ./.github/workflows/build.yml
@@ -39,9 +39,9 @@ jobs:
       base-image: nvidia/cuda
       base-tag: 12.4.1-devel-ubuntu22.04
       cuda-version: "12.4.1"
-      nccl-version: 2.25.1-1
+      nccl-version: 2.26.2-1
       cuda-samples-version: "12.4"
-      hpcx-distribution: "hpcx-v2.22-gcc-doca_ofed-ubuntu22.04-cuda12"
+      hpcx-distribution: "hpcx-v2.22.1-gcc-doca_ofed-ubuntu22.04-cuda12"
 
   cu126:
     uses: ./.github/workflows/build.yml
@@ -57,9 +57,9 @@ jobs:
       base-image: nvidia/cuda
       base-tag: 12.6.3-devel-ubuntu22.04
       cuda-version: "12.6.3"
-      nccl-version: 2.25.1-1
+      nccl-version: 2.26.2-1
       cuda-samples-version: "12.5"
-      hpcx-distribution: "hpcx-v2.22-gcc-doca_ofed-ubuntu22.04-cuda12"
+      hpcx-distribution: "hpcx-v2.22.1-gcc-doca_ofed-ubuntu22.04-cuda12"
 
   cu128:
     uses: ./.github/workflows/build.yml
@@ -73,8 +73,8 @@ jobs:
       folder: .
       dockerfile: Dockerfile.ubuntu22
       base-image: nvidia/cuda
-      base-tag: 12.8.0-devel-ubuntu22.04
-      cuda-version: "12.8.0"
-      nccl-version: 2.25.1-1
+      base-tag: 12.8.1-devel-ubuntu22.04
+      cuda-version: "12.8.1"
+      nccl-version: 2.26.2-1
       cuda-samples-version: "12.5"
-      hpcx-distribution: "hpcx-v2.22-gcc-doca_ofed-ubuntu22.04-cuda12"
+      hpcx-distribution: "hpcx-v2.22.1-gcc-doca_ofed-ubuntu22.04-cuda12"

--- a/Dockerfile.ubuntu20
+++ b/Dockerfile.ubuntu20
@@ -1,10 +1,10 @@
 # syntax=docker/dockerfile:1.4
 
-ARG CUDA_VERSION=12.8.0
+ARG CUDA_VERSION=12.8.1
 ARG BASE_IMAGE=nvidia/cuda:${CUDA_VERSION}-devel-ubuntu20.04
 FROM ${BASE_IMAGE} AS base
 
-ENV NV_CUDNN_VERSION 9.7.0.66-1
+ENV NV_CUDNN_VERSION 9.8.0.87-1
 ENV NV_CUDNN_PACKAGE_NAME libcudnn9-cuda-12
 ENV NV_CUDNN_PACKAGE libcudnn9-cuda-12=${NV_CUDNN_VERSION}
 ENV NV_CUDNN_PACKAGE_DEV libcudnn9-dev-cuda-12=${NV_CUDNN_VERSION}
@@ -58,7 +58,7 @@ RUN apt-get -qq update && \
 
 FROM builder-base AS libnccl2
 # NCCL
-ARG TARGET_NCCL_VERSION='2.25.1-1'
+ARG TARGET_NCCL_VERSION='2.26.2-1'
 ARG CUDA_ARCH_LIST='70 80 89 90 100'
 # Converts CUDA_ARCH_LIST to '-gencode=arch=compute_XX,code=sm_XX -gencode=...' format with PTX for the last listed arch
 RUN case "${CUDA_VERSION}" in 12.[0-7].*) \
@@ -129,7 +129,7 @@ RUN mkdir /tmp/build && \
 FROM builder-base AS hpcx
 # HPC-X
 # grep + sed is used as a workaround to update hardcoded pkg-config / libtools archive / CMake prefixes
-ARG HPCX_DISTRIBUTION="hpcx-v2.22-gcc-doca_ofed-ubuntu20.04-cuda12"
+ARG HPCX_DISTRIBUTION="hpcx-v2.22.1-gcc-doca_ofed-ubuntu20.04-cuda12"
 RUN cd /tmp && \
     DIST_NAME="${HPCX_DISTRIBUTION}-$(uname -m)" && \
     HPCX_DIR="/opt/hpcx" && \

--- a/Dockerfile.ubuntu22
+++ b/Dockerfile.ubuntu22
@@ -1,10 +1,10 @@
 # syntax=docker/dockerfile:1.4
 
-ARG CUDA_VERSION=12.8.0
+ARG CUDA_VERSION=12.8.1
 ARG BASE_IMAGE=nvidia/cuda:${CUDA_VERSION}-devel-ubuntu22.04
 FROM ${BASE_IMAGE} AS base
 
-ENV NV_CUDNN_VERSION 9.7.0.66-1
+ENV NV_CUDNN_VERSION 9.8.0.87-1
 ENV NV_CUDNN_PACKAGE_NAME libcudnn9-cuda-12
 ENV NV_CUDNN_PACKAGE libcudnn9-cuda-12=${NV_CUDNN_VERSION}
 ENV NV_CUDNN_PACKAGE_DEV libcudnn9-dev-cuda-12=${NV_CUDNN_VERSION}
@@ -58,7 +58,7 @@ RUN apt-get -qq update && \
 
 FROM builder-base AS libnccl2
 # NCCL
-ARG TARGET_NCCL_VERSION='2.25.1-1'
+ARG TARGET_NCCL_VERSION='2.26.2-1'
 ARG CUDA_ARCH_LIST='70 80 89 90 100'
 # Converts CUDA_ARCH_LIST to '-gencode=arch=compute_XX,code=sm_XX -gencode=...' format with PTX for the last listed arch
 RUN case "${CUDA_VERSION}" in 12.[0-7].*) \
@@ -129,7 +129,7 @@ RUN mkdir /tmp/build && \
 FROM builder-base AS hpcx
 # HPC-X
 # grep + sed is used as a workaround to update hardcoded pkg-config / libtools archive / CMake prefixes
-ARG HPCX_DISTRIBUTION="hpcx-v2.22-gcc-doca_ofed-ubuntu22.04-cuda12"
+ARG HPCX_DISTRIBUTION="hpcx-v2.22.1-gcc-doca_ofed-ubuntu22.04-cuda12"
 RUN cd /tmp && \
     DIST_NAME="${HPCX_DISTRIBUTION}-$(uname -m)" && \
     HPCX_DIR="/opt/hpcx" && \

--- a/README.md
+++ b/README.md
@@ -49,20 +49,20 @@ the following components:
 CoreWeave
 also [publishes images](https://github.com/coreweave/nccl-tests/pkgs/container/nccl-tests)
 built from these Dockerfiles that can be used as base for your own images.  
-The images below include **NCCL v2.25.1-1**, **HPC-X v2.22.0**, and **cuDNN v9.7.0.66-1**.  
+The images below include **NCCL v2.26.2-1**, **HPC-X v2.22.1**, and **cuDNN v9.8.0.87-1**.  
 Each image is multi-arch, and can be used for both `linux/amd64` and `linux/arm64` containers.
 Compute capabilities up to Blackwell (10.0) are supported.
 
 | **Image Tag**                                                              | **Ubuntu** | **CUDA** |
 |----------------------------------------------------------------------------|------------|----------|
-| ghcr.io/coreweave/nccl-tests:12.8.0-devel-ubuntu22.04-nccl2.25.1-1-57fa979 | 22.04      | 12.8.0   |
-| ghcr.io/coreweave/nccl-tests:12.6.3-devel-ubuntu22.04-nccl2.25.1-1-57fa979 | 22.04      | 12.6.3   |
-| ghcr.io/coreweave/nccl-tests:12.4.1-devel-ubuntu22.04-nccl2.25.1-1-57fa979 | 22.04      | 12.4.1   |
-| ghcr.io/coreweave/nccl-tests:12.2.2-devel-ubuntu22.04-nccl2.25.1-1-57fa979 | 22.04      | 12.2.2   |
-| ghcr.io/coreweave/nccl-tests:12.8.0-devel-ubuntu20.04-nccl2.25.1-1-4e02d6a | 20.04      | 12.8.0   |
-| ghcr.io/coreweave/nccl-tests:12.6.3-devel-ubuntu20.04-nccl2.25.1-1-4e02d6a | 20.04      | 12.6.3   |
-| ghcr.io/coreweave/nccl-tests:12.4.1-devel-ubuntu20.04-nccl2.25.1-1-4e02d6a | 20.04      | 12.4.1   |
-| ghcr.io/coreweave/nccl-tests:12.2.2-devel-ubuntu20.04-nccl2.25.1-1-4e02d6a | 20.04      | 12.2.2   |
+| ghcr.io/coreweave/nccl-tests:12.8.1-devel-ubuntu22.04-nccl2.26.2-1-0708d2e | 22.04      | 12.8.1   |
+| ghcr.io/coreweave/nccl-tests:12.6.3-devel-ubuntu22.04-nccl2.26.2-1-0708d2e | 22.04      | 12.6.3   |
+| ghcr.io/coreweave/nccl-tests:12.4.1-devel-ubuntu22.04-nccl2.26.2-1-0708d2e | 22.04      | 12.4.1   |
+| ghcr.io/coreweave/nccl-tests:12.2.2-devel-ubuntu22.04-nccl2.26.2-1-0708d2e | 22.04      | 12.2.2   |
+| ghcr.io/coreweave/nccl-tests:12.8.1-devel-ubuntu20.04-nccl2.26.2-1-0708d2e | 20.04      | 12.8.1   |
+| ghcr.io/coreweave/nccl-tests:12.6.3-devel-ubuntu20.04-nccl2.26.2-1-0708d2e | 20.04      | 12.6.3   |
+| ghcr.io/coreweave/nccl-tests:12.4.1-devel-ubuntu20.04-nccl2.26.2-1-0708d2e | 20.04      | 12.4.1   |
+| ghcr.io/coreweave/nccl-tests:12.2.2-devel-ubuntu20.04-nccl2.26.2-1-0708d2e | 20.04      | 12.2.2   |
 
 ## Running NCCL Tests
 

--- a/slurm/nccl-test-distributed-gb200-nvl72-enroot.slurm
+++ b/slurm/nccl-test-distributed-gb200-nvl72-enroot.slurm
@@ -28,6 +28,6 @@ echo "Using nodes: $SLURM_JOB_NODELIST"
 # Save the container to a NFS mount for speed ups on large jobs
 # --container-save=/mnt/home/user/nccl-tests.sqsh -> --container-image=/mnt/home/user/nccl-tests.sqsh
 
-srun --container-image=ghcr.io#coreweave/nccl-tests:12.8.0-devel-ubuntu22.04-nccl2.25.1-1-57fa979 \
+srun --container-image=ghcr.io#coreweave/nccl-tests:12.8.1-devel-ubuntu22.04-nccl2.26.2-1-0708d2e \
      --mpi=pmix --no-container-remap-root --container-mount-home \
      /opt/nccl_tests/build/all_reduce_perf -b 512M -e 8G -f 2 -g 1


### PR DESCRIPTION
# Updates for CUDA, NCCL, HPC-X, and cuDNN

This change updates the CUDA 12.8 image to use CUDA 12.8.1, up from 12.8.0, and updates the following components across all built images:

| Ver | NCCL     | HPC-X  | cuDNN      |
|-----|----------|--------|------------|
| Old | 2.25.1-1 | 2.22.0 | 9.7.0.66-1 |
| New | 2.26.2-1 | 2.22.1 | 9.8.0.87-1 |