### PR TITLE
feat: Update the GB200 with latest env var recommendations

### DIFF
--- a/slurm/nccl-test-distributed-gb200-nvl72-enroot.slurm
+++ b/slurm/nccl-test-distributed-gb200-nvl72-enroot.slurm
@@ -19,7 +19,7 @@ export NCCL_COLLNET_ENABLE=0
 
 export NVIDIA_IMEX_CHANNELS=0
 export NCCL_NVLS_ENABLE=0
-
+export NCCL_NET_GDR_C2C=1
 export PMIX_MCA_gds='^ds12'
 
 # Log the assigned nodes


### PR DESCRIPTION
[NCCL_NET_GDR_C2C docs](https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/env.html#nccl-net-gdr-c2c)

> The NCCL_NET_GDR_C2C variable enables GPU Direct RDMA when sending data via a NIC attached to a CPU (i.e. distance PHB) where the CPU is connected to the GPU via a C2C interconnect. This effectively overrides the NCCL_NET_GDR_LEVEL setting for this particular NIC.

Performance with this example running across 20 racks
```
#  Rank 1439 Group  0 Pid  21082 on slurm-gb200-218-073 device  3 [0x01] NVIDIA GB200
#
#                                                              out-of-place                       in-place          
#       size         count      type   redop    root     time   algbw   busbw #wrong     time   algbw   busbw #wrong
#        (B)    (elements)                               (us)  (GB/s)  (GB/s)            (us)  (GB/s)  (GB/s)       
   536870912     134217728     float     sum      -1   7108.4   75.53  150.95      0   7145.8   75.13  150.16      0
  1073741824     268435456     float     sum      -1   9805.7  109.50  218.85      0   9819.6  109.35  218.54      0
  2147483648     536870912     float     sum      -1    14980  143.36  286.52      0    15087  142.34  284.49      0
  4294967296    1073741824     float     sum      -1    24782  173.31  346.38      0    24975  171.97  343.71      0
  8589934592    2147483648     float     sum      -1    45004  190.87  381.48      0    44930  191.19  382.11      0
 17179869184    4294967296     float     sum      -1    84625  203.01  405.74      0    84828  202.53  404.77      0
# Out of bounds values : 0 OK
# Avg bus bandwidth    : 297.808 
```