### PR TITLE
feat: Update to CUDA 12.9.0 & NCCL 2.26.5-1

### DIFF
--- a/.github/workflows/ubuntu-20.yml
+++ b/.github/workflows/ubuntu-20.yml
@@ -21,7 +21,7 @@ jobs:
       base-image: nvidia/cuda
       base-tag: 12.2.2-devel-ubuntu20.04
       cuda-version: "12.2.2"
-      nccl-version: 2.26.2-1
+      nccl-version: 2.26.5-1
       cuda-samples-version: "12.2"
       hpcx-distribution: "hpcx-v2.22.1-gcc-doca_ofed-ubuntu20.04-cuda12"
 
@@ -39,7 +39,7 @@ jobs:
       base-image: nvidia/cuda
       base-tag: 12.4.1-devel-ubuntu20.04
       cuda-version: "12.4.1"
-      nccl-version: 2.26.2-1
+      nccl-version: 2.26.5-1
       cuda-samples-version: "12.4"
       hpcx-distribution: "hpcx-v2.22.1-gcc-doca_ofed-ubuntu20.04-cuda12"
 
@@ -57,7 +57,7 @@ jobs:
       base-image: nvidia/cuda
       base-tag: 12.6.3-devel-ubuntu20.04
       cuda-version: "12.6.3"
-      nccl-version: 2.26.2-1
+      nccl-version: 2.26.5-1
       cuda-samples-version: "12.5"
       hpcx-distribution: "hpcx-v2.22.1-gcc-doca_ofed-ubuntu20.04-cuda12"
 
@@ -75,6 +75,6 @@ jobs:
       base-image: nvidia/cuda
       base-tag: 12.8.1-devel-ubuntu20.04
       cuda-version: "12.8.1"
-      nccl-version: 2.26.2-1
+      nccl-version: 2.26.5-1
       cuda-samples-version: "12.5"
       hpcx-distribution: "hpcx-v2.22.1-gcc-doca_ofed-ubuntu20.04-cuda12"

--- a/.github/workflows/ubuntu-20.yml
+++ b/.github/workflows/ubuntu-20.yml
@@ -23,7 +23,7 @@ jobs:
       cuda-version: "12.2.2"
       nccl-version: 2.26.5-1
       cuda-samples-version: "12.2"
-      hpcx-distribution: "hpcx-v2.22.1-gcc-doca_ofed-ubuntu20.04-cuda12"
+      hpcx-distribution: "hpcx-v2.23-gcc-doca_ofed-ubuntu20.04-cuda12"
 
   cu124:
     uses: ./.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
       cuda-version: "12.4.1"
       nccl-version: 2.26.5-1
       cuda-samples-version: "12.4"
-      hpcx-distribution: "hpcx-v2.22.1-gcc-doca_ofed-ubuntu20.04-cuda12"
+      hpcx-distribution: "hpcx-v2.23-gcc-doca_ofed-ubuntu20.04-cuda12"
 
   cu126:
     uses: ./.github/workflows/build.yml
@@ -59,7 +59,7 @@ jobs:
       cuda-version: "12.6.3"
       nccl-version: 2.26.5-1
       cuda-samples-version: "12.5"
-      hpcx-distribution: "hpcx-v2.22.1-gcc-doca_ofed-ubuntu20.04-cuda12"
+      hpcx-distribution: "hpcx-v2.23-gcc-doca_ofed-ubuntu20.04-cuda12"
 
   cu128:
     uses: ./.github/workflows/build.yml
@@ -77,4 +77,22 @@ jobs:
       cuda-version: "12.8.1"
       nccl-version: 2.26.5-1
       cuda-samples-version: "12.5"
-      hpcx-distribution: "hpcx-v2.22.1-gcc-doca_ofed-ubuntu20.04-cuda12"
+      hpcx-distribution: "hpcx-v2.23-gcc-doca_ofed-ubuntu20.04-cuda12"
+
+  cu129:
+    uses: ./.github/workflows/build.yml
+    secrets:
+      ORG_BUILDKIT_CLIENT_TOKEN: ${{ secrets.ORG_BUILDKIT_CLIENT_TOKEN }}
+      BUILDKIT_CONSUMER_DOPPLER_PROJECT: ${{ secrets.BUILDKIT_CONSUMER_DOPPLER_PROJECT }}
+      BUILDKIT_CONSUMER_ENDPOINT: ${{ secrets.BUILDKIT_CONSUMER_ENDPOINT }}
+      BUILDKIT_CONSUMER_AMD64_ENDPOINT: ${{ secrets.BUILDKIT_CONSUMER_AMD64_ENDPOINT }}
+      BUILDKIT_CONSUMER_ARM64_ENDPOINT: ${{ secrets.BUILDKIT_CONSUMER_ARM64_ENDPOINT }}
+    with:
+      folder: .
+      dockerfile: Dockerfile.ubuntu20
+      base-image: nvidia/cuda
+      base-tag: 12.9.0-devel-ubuntu20.04
+      cuda-version: "12.9.0"
+      nccl-version: 2.26.5-1
+      cuda-samples-version: "12.5"
+      hpcx-distribution: "hpcx-v2.23-gcc-doca_ofed-ubuntu20.04-cuda12"

--- a/.github/workflows/ubuntu-22.yml
+++ b/.github/workflows/ubuntu-22.yml
@@ -21,7 +21,7 @@ jobs:
       base-image: nvidia/cuda
       base-tag: 12.2.2-devel-ubuntu22.04
       cuda-version: "12.2.2"
-      nccl-version: 2.26.2-1
+      nccl-version: 2.26.5-1
       cuda-samples-version: "12.2"
       hpcx-distribution: "hpcx-v2.22.1-gcc-doca_ofed-ubuntu22.04-cuda12"
 
@@ -39,7 +39,7 @@ jobs:
       base-image: nvidia/cuda
       base-tag: 12.4.1-devel-ubuntu22.04
       cuda-version: "12.4.1"
-      nccl-version: 2.26.2-1
+      nccl-version: 2.26.5-1
       cuda-samples-version: "12.4"
       hpcx-distribution: "hpcx-v2.22.1-gcc-doca_ofed-ubuntu22.04-cuda12"
 
@@ -57,7 +57,7 @@ jobs:
       base-image: nvidia/cuda
       base-tag: 12.6.3-devel-ubuntu22.04
       cuda-version: "12.6.3"
-      nccl-version: 2.26.2-1
+      nccl-version: 2.26.5-1
       cuda-samples-version: "12.5"
       hpcx-distribution: "hpcx-v2.22.1-gcc-doca_ofed-ubuntu22.04-cuda12"
 
@@ -75,6 +75,6 @@ jobs:
       base-image: nvidia/cuda
       base-tag: 12.8.1-devel-ubuntu22.04
       cuda-version: "12.8.1"
-      nccl-version: 2.26.2-1
+      nccl-version: 2.26.5-1
       cuda-samples-version: "12.5"
       hpcx-distribution: "hpcx-v2.22.1-gcc-doca_ofed-ubuntu22.04-cuda12"

--- a/.github/workflows/ubuntu-22.yml
+++ b/.github/workflows/ubuntu-22.yml
@@ -23,7 +23,7 @@ jobs:
       cuda-version: "12.2.2"
       nccl-version: 2.26.5-1
       cuda-samples-version: "12.2"
-      hpcx-distribution: "hpcx-v2.22.1-gcc-doca_ofed-ubuntu22.04-cuda12"
+      hpcx-distribution: "hpcx-v2.23-gcc-doca_ofed-ubuntu22.04-cuda12"
 
   cu124:
     uses: ./.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
       cuda-version: "12.4.1"
       nccl-version: 2.26.5-1
       cuda-samples-version: "12.4"
-      hpcx-distribution: "hpcx-v2.22.1-gcc-doca_ofed-ubuntu22.04-cuda12"
+      hpcx-distribution: "hpcx-v2.23-gcc-doca_ofed-ubuntu22.04-cuda12"
 
   cu126:
     uses: ./.github/workflows/build.yml
@@ -59,7 +59,7 @@ jobs:
       cuda-version: "12.6.3"
       nccl-version: 2.26.5-1
       cuda-samples-version: "12.5"
-      hpcx-distribution: "hpcx-v2.22.1-gcc-doca_ofed-ubuntu22.04-cuda12"
+      hpcx-distribution: "hpcx-v2.23-gcc-doca_ofed-ubuntu22.04-cuda12"
 
   cu128:
     uses: ./.github/workflows/build.yml
@@ -77,4 +77,22 @@ jobs:
       cuda-version: "12.8.1"
       nccl-version: 2.26.5-1
       cuda-samples-version: "12.5"
-      hpcx-distribution: "hpcx-v2.22.1-gcc-doca_ofed-ubuntu22.04-cuda12"
+      hpcx-distribution: "hpcx-v2.23-gcc-doca_ofed-ubuntu22.04-cuda12"
+
+  cu129:
+    uses: ./.github/workflows/build.yml
+    secrets:
+      ORG_BUILDKIT_CLIENT_TOKEN: ${{ secrets.ORG_BUILDKIT_CLIENT_TOKEN }}
+      BUILDKIT_CONSUMER_DOPPLER_PROJECT: ${{ secrets.BUILDKIT_CONSUMER_DOPPLER_PROJECT }}
+      BUILDKIT_CONSUMER_ENDPOINT: ${{ secrets.BUILDKIT_CONSUMER_ENDPOINT }}
+      BUILDKIT_CONSUMER_AMD64_ENDPOINT: ${{ secrets.BUILDKIT_CONSUMER_AMD64_ENDPOINT }}
+      BUILDKIT_CONSUMER_ARM64_ENDPOINT: ${{ secrets.BUILDKIT_CONSUMER_ARM64_ENDPOINT }}
+    with:
+      folder: .
+      dockerfile: Dockerfile.ubuntu22
+      base-image: nvidia/cuda
+      base-tag: 12.9.0-devel-ubuntu22.04
+      cuda-version: "12.9.0"
+      nccl-version: 2.26.5-1
+      cuda-samples-version: "12.5"
+      hpcx-distribution: "hpcx-v2.23-gcc-doca_ofed-ubuntu22.04-cuda12"

--- a/Dockerfile.ubuntu20
+++ b/Dockerfile.ubuntu20
@@ -129,7 +129,7 @@ RUN mkdir /tmp/build && \
 FROM builder-base AS hpcx
 # HPC-X
 # grep + sed is used as a workaround to update hardcoded pkg-config / libtools archive / CMake prefixes
-ARG HPCX_DISTRIBUTION="hpcx-v2.22.1-gcc-doca_ofed-ubuntu20.04-cuda12"
+ARG HPCX_DISTRIBUTION="hpcx-v2.23-gcc-doca_ofed-ubuntu20.04-cuda12"
 RUN cd /tmp && \
     DIST_NAME="${HPCX_DISTRIBUTION}-$(uname -m)" && \
     HPCX_DIR="/opt/hpcx" && \

--- a/Dockerfile.ubuntu20
+++ b/Dockerfile.ubuntu20
@@ -58,7 +58,7 @@ RUN apt-get -qq update && \
 
 FROM builder-base AS libnccl2
 # NCCL
-ARG TARGET_NCCL_VERSION='2.26.2-1'
+ARG TARGET_NCCL_VERSION='2.26.5-1'
 ARG CUDA_ARCH_LIST='70 80 89 90 100'
 # Converts CUDA_ARCH_LIST to '-gencode=arch=compute_XX,code=sm_XX -gencode=...' format with PTX for the last listed arch
 RUN case "${CUDA_VERSION}" in 12.[0-7].*) \

--- a/Dockerfile.ubuntu22
+++ b/Dockerfile.ubuntu22
@@ -129,7 +129,7 @@ RUN mkdir /tmp/build && \
 FROM builder-base AS hpcx
 # HPC-X
 # grep + sed is used as a workaround to update hardcoded pkg-config / libtools archive / CMake prefixes
-ARG HPCX_DISTRIBUTION="hpcx-v2.22.1-gcc-doca_ofed-ubuntu22.04-cuda12"
+ARG HPCX_DISTRIBUTION="hpcx-v2.23-gcc-doca_ofed-ubuntu22.04-cuda12"
 RUN cd /tmp && \
     DIST_NAME="${HPCX_DISTRIBUTION}-$(uname -m)" && \
     HPCX_DIR="/opt/hpcx" && \

--- a/Dockerfile.ubuntu22
+++ b/Dockerfile.ubuntu22
@@ -58,7 +58,7 @@ RUN apt-get -qq update && \
 
 FROM builder-base AS libnccl2
 # NCCL
-ARG TARGET_NCCL_VERSION='2.26.2-1'
+ARG TARGET_NCCL_VERSION='2.26.5-1'
 ARG CUDA_ARCH_LIST='70 80 89 90 100'
 # Converts CUDA_ARCH_LIST to '-gencode=arch=compute_XX,code=sm_XX -gencode=...' format with PTX for the last listed arch
 RUN case "${CUDA_VERSION}" in 12.[0-7].*) \

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ find the following examples of 64 GPU (8 node) runs:
  - [H100 without enroot](./slurm/nccl-test-distributed-h100-64.slurm)
  - [H100 with enroot](./slurm/nccl-test-distributed-h100-64-enroot.slurm)
  - [H100 with enroot and SHARP](./slurm/nccl-test-distributed-h100-64-enroot-sharp.slurm)
- - [GB200 with enroot](./slurm/nccl-test-distributed-gb100-nvl72-enroot.slurm)
+ - [GB200 with enroot](./slurm/nccl-test-distributed-gb200-nvl72-enroot.slurm)
 
 #### Running Jobs
 

--- a/README.md
+++ b/README.md
@@ -8,13 +8,23 @@ the vast majority of all distributed training frameworks such as
 [PyTorch Distributed](https://pytorch.org/tutorials/beginner/dist_overview.html)
 and [Horovod](https://horovod.readthedocs.io/en/stable/gpus_include.html).
 
-NCCL is supported across all CoreWeave NVIDIA GPUs over Ethernet. In addition,
-the specialized A100 HGX clusters are built to the design of NVIDIA DGX
-SuperPODs, including
-[NVIDIA Quantum InfiniBand](https://www.nvidia.com/en-us/networking/quantum2/)
+NCCL is supported across CoreWeave NVIDIA GPUs over Ethernet and InfiniBand. In addition,
+the specialized GB200 NVL72 clusters are built with
+[NVIDIA Quantum-X800 InfiniBand](https://www.nvidia.com/en-us/networking/products/infiniband/quantum-x800/)
 networking and in-network collections using
-[NVIDIA SHARP](https://docs.nvidia.com/networking/display/SHARPv270/Introduction)
+[NVIDIA SHARP](https://docs.nvidia.com/networking/display/sharpv300/introduction)
 to deliver the highest distributed training performance possible.
+
+* [NCCL for Distributed Training](#nccl-for-distributed-training)
+  * [Docker Images](#docker-images)
+  * [Running NCCL Tests](#running-nccl-tests)
+    * [MPI Operator](#mpi-operator)
+      * [Running Jobs](#running-jobs)
+    * [Slurm](#slurm)
+      * [Running Jobs](#running-jobs-1)
+      * [Enroot](#enroot)
+  * [Running DeepSpeed Training Jobs](#running-deepspeed-training-jobs)
+  * [GDRCopy](#gdrcopy)
 
 ## Docker Images
 
@@ -33,7 +43,7 @@ the following components:
 - NVIDIA [GDRCopy](https://developer.nvidia.com/gdrcopy) libraries leverage
   GPUDirect RDMA for improved GPU to host memory copy performance in certain
   applications. The kernel support for GDRCopy exists on CoreWeave's
-  bare-metal nodes. GDRCopy is only supported on A100 training clusters.
+  bare-metal nodes.
 - NVIDIA [NCCL SHARP Plugin](https://github.com/Mellanox/nccl-rdma-sharp-plugins)
   for SHARP support in NCCL
 - NVIDIA [NCCL Tests](https://github.com/NVIDIA/nccl-tests) for verification
@@ -127,7 +137,7 @@ terminating before starting a new job with the same name.
 ### Slurm
 
 CoreWeave provides a way to deploy a slurm cluster on top of our managed
-kubernetes cluster using a tool called `sunk`.
+Kubernetes cluster using a tool called `sunk`.
 
 Example `SBATCH` scripts are provided in the `slurm/` directory. There you'll
 find the following examples of 64 GPU (8 node) runs:
@@ -136,6 +146,7 @@ find the following examples of 64 GPU (8 node) runs:
  - [H100 without enroot](./slurm/nccl-test-distributed-h100-64.slurm)
  - [H100 with enroot](./slurm/nccl-test-distributed-h100-64-enroot.slurm)
  - [H100 with enroot and SHARP](./slurm/nccl-test-distributed-h100-64-enroot-sharp.slurm)
+ - [GB200 with enroot](./slurm/nccl-test-distributed-gb100-nvl72-enroot.slurm)
 
 #### Running Jobs
 
@@ -149,7 +160,7 @@ To start the NCCL test, submit the job via `sbatch`:
 
 ```bash
 export PARTITION=<enter partition>
-sbatch --partition="$PARTITION" nccl-test-distributed-a100-64.slurm
+sbatch --partition="$PARTITION" nccl-test-distributed-h100-64.slurm
 ```
 
 The logs will be written to `./nccl_test.out`.

--- a/README.md
+++ b/README.md
@@ -25,6 +25,11 @@ to deliver the highest distributed training performance possible.
       * [Enroot](#enroot)
   * [Running DeepSpeed Training Jobs](#running-deepspeed-training-jobs)
   * [GDRCopy](#gdrcopy)
+  * [Expected Performance](#expected-performance)
+    * [GB200](#gb200)
+      * [Single Rack](#single-rack)
+      * [2 Racks](#2-racks)
+      * [20 Racks](#20-racks)
 
 ## Docker Images
 

--- a/README.md
+++ b/README.md
@@ -59,20 +59,20 @@ the following components:
 CoreWeave
 also [publishes images](https://github.com/coreweave/nccl-tests/pkgs/container/nccl-tests)
 built from these Dockerfiles that can be used as base for your own images.  
-The images below include **NCCL v2.26.2-1**, **HPC-X v2.22.1**, and **cuDNN v9.8.0.87-1**.  
+The images below include **NCCL v2.26.5-1**, **HPC-X v2.22.1**, and **cuDNN v9.8.0.87-1**.  
 Each image is multi-arch, and can be used for both `linux/amd64` and `linux/arm64` containers.
 Compute capabilities up to Blackwell (10.0) are supported.
 
 | **Image Tag**                                                              | **Ubuntu** | **CUDA** |
 |----------------------------------------------------------------------------|------------|----------|
-| ghcr.io/coreweave/nccl-tests:12.8.1-devel-ubuntu22.04-nccl2.26.2-1-0708d2e | 22.04      | 12.8.1   |
-| ghcr.io/coreweave/nccl-tests:12.6.3-devel-ubuntu22.04-nccl2.26.2-1-0708d2e | 22.04      | 12.6.3   |
-| ghcr.io/coreweave/nccl-tests:12.4.1-devel-ubuntu22.04-nccl2.26.2-1-0708d2e | 22.04      | 12.4.1   |
-| ghcr.io/coreweave/nccl-tests:12.2.2-devel-ubuntu22.04-nccl2.26.2-1-0708d2e | 22.04      | 12.2.2   |
-| ghcr.io/coreweave/nccl-tests:12.8.1-devel-ubuntu20.04-nccl2.26.2-1-0708d2e | 20.04      | 12.8.1   |
-| ghcr.io/coreweave/nccl-tests:12.6.3-devel-ubuntu20.04-nccl2.26.2-1-0708d2e | 20.04      | 12.6.3   |
-| ghcr.io/coreweave/nccl-tests:12.4.1-devel-ubuntu20.04-nccl2.26.2-1-0708d2e | 20.04      | 12.4.1   |
-| ghcr.io/coreweave/nccl-tests:12.2.2-devel-ubuntu20.04-nccl2.26.2-1-0708d2e | 20.04      | 12.2.2   |
+| ghcr.io/coreweave/nccl-tests:12.8.1-devel-ubuntu22.04-nccl2.26.5-1-4658d92 | 22.04      | 12.8.1   |
+| ghcr.io/coreweave/nccl-tests:12.6.3-devel-ubuntu22.04-nccl2.26.5-1-4658d92 | 22.04      | 12.6.3   |
+| ghcr.io/coreweave/nccl-tests:12.4.1-devel-ubuntu22.04-nccl2.26.5-1-4658d92 | 22.04      | 12.4.1   |
+| ghcr.io/coreweave/nccl-tests:12.2.2-devel-ubuntu22.04-nccl2.26.5-1-4658d92 | 22.04      | 12.2.2   |
+| ghcr.io/coreweave/nccl-tests:12.8.1-devel-ubuntu20.04-nccl2.26.5-1-4658d92 | 20.04      | 12.8.1   |
+| ghcr.io/coreweave/nccl-tests:12.6.3-devel-ubuntu20.04-nccl2.26.5-1-4658d92 | 20.04      | 12.6.3   |
+| ghcr.io/coreweave/nccl-tests:12.4.1-devel-ubuntu20.04-nccl2.26.5-1-4658d92 | 20.04      | 12.4.1   |
+| ghcr.io/coreweave/nccl-tests:12.2.2-devel-ubuntu20.04-nccl2.26.5-1-4658d92 | 20.04      | 12.2.2   |
 
 ## Running NCCL Tests
 

--- a/README.md
+++ b/README.md
@@ -59,20 +59,22 @@ the following components:
 CoreWeave
 also [publishes images](https://github.com/coreweave/nccl-tests/pkgs/container/nccl-tests)
 built from these Dockerfiles that can be used as base for your own images.  
-The images below include **NCCL v2.26.5-1**, **HPC-X v2.22.1**, and **cuDNN v9.8.0.87-1**.  
+The images below include **NCCL v2.26.5-1**, **HPC-X v2.23**, and **cuDNN v9.8.0.87-1**.  
 Each image is multi-arch, and can be used for both `linux/amd64` and `linux/arm64` containers.
 Compute capabilities up to Blackwell (10.0) are supported.
 
 | **Image Tag**                                                              | **Ubuntu** | **CUDA** |
 |----------------------------------------------------------------------------|------------|----------|
-| ghcr.io/coreweave/nccl-tests:12.8.1-devel-ubuntu22.04-nccl2.26.5-1-4658d92 | 22.04      | 12.8.1   |
-| ghcr.io/coreweave/nccl-tests:12.6.3-devel-ubuntu22.04-nccl2.26.5-1-4658d92 | 22.04      | 12.6.3   |
-| ghcr.io/coreweave/nccl-tests:12.4.1-devel-ubuntu22.04-nccl2.26.5-1-4658d92 | 22.04      | 12.4.1   |
-| ghcr.io/coreweave/nccl-tests:12.2.2-devel-ubuntu22.04-nccl2.26.5-1-4658d92 | 22.04      | 12.2.2   |
-| ghcr.io/coreweave/nccl-tests:12.8.1-devel-ubuntu20.04-nccl2.26.5-1-4658d92 | 20.04      | 12.8.1   |
-| ghcr.io/coreweave/nccl-tests:12.6.3-devel-ubuntu20.04-nccl2.26.5-1-4658d92 | 20.04      | 12.6.3   |
-| ghcr.io/coreweave/nccl-tests:12.4.1-devel-ubuntu20.04-nccl2.26.5-1-4658d92 | 20.04      | 12.4.1   |
-| ghcr.io/coreweave/nccl-tests:12.2.2-devel-ubuntu20.04-nccl2.26.5-1-4658d92 | 20.04      | 12.2.2   |
+| ghcr.io/coreweave/nccl-tests:12.9.0-devel-ubuntu22.04-nccl2.26.5-1-ba5f58f | 22.04      | 12.9.0   |
+| ghcr.io/coreweave/nccl-tests:12.8.1-devel-ubuntu22.04-nccl2.26.5-1-ba5f58f | 22.04      | 12.8.1   |
+| ghcr.io/coreweave/nccl-tests:12.6.3-devel-ubuntu22.04-nccl2.26.5-1-ba5f58f | 22.04      | 12.6.3   |
+| ghcr.io/coreweave/nccl-tests:12.4.1-devel-ubuntu22.04-nccl2.26.5-1-ba5f58f | 22.04      | 12.4.1   |
+| ghcr.io/coreweave/nccl-tests:12.2.2-devel-ubuntu22.04-nccl2.26.5-1-ba5f58f | 22.04      | 12.2.2   |
+| ghcr.io/coreweave/nccl-tests:12.9.0-devel-ubuntu20.04-nccl2.26.5-1-ba5f58f | 20.04      | 12.9.0   |
+| ghcr.io/coreweave/nccl-tests:12.8.1-devel-ubuntu20.04-nccl2.26.5-1-ba5f58f | 20.04      | 12.8.1   |
+| ghcr.io/coreweave/nccl-tests:12.6.3-devel-ubuntu20.04-nccl2.26.5-1-ba5f58f | 20.04      | 12.6.3   |
+| ghcr.io/coreweave/nccl-tests:12.4.1-devel-ubuntu20.04-nccl2.26.5-1-ba5f58f | 20.04      | 12.4.1   |
+| ghcr.io/coreweave/nccl-tests:12.2.2-devel-ubuntu20.04-nccl2.26.5-1-ba5f58f | 20.04      | 12.2.2   |
 
 ## Running NCCL Tests
 


### PR DESCRIPTION
# CUDA 12.9, NCCL 2.26.5-1, HPC-X 2.23, and documentation updates

This change adds builds for CUDA 12.9 and updates NCCL to version 2.26.5-1, up from 2.26.2-1, and HPC-X to version 2.23, up from 2.22.1. Also included are updated versions of the edits from #46 that no longer conflict with the recent README changes.