### PR TITLE
fix(slurm): Use more consistent env vars and `srun` flags

### DIFF
--- a/slurm/README.md
+++ b/slurm/README.md
@@ -1,24 +1,29 @@
 # Example NCCL Test Scripts
 
-These slurm sbatch scripts are good starting points to use for submission scripts for your own training jobs.
+These Slurm sbatch scripts are good starting points to use for submission scripts for your own training jobs.
 
 ## Basic Usage
 
-Use a partition corresponding to one specific type of gpu (e.g. h100, h200). Depending on your cluster, the default partition may include different gpus that will be on different infiniband fabrics. See what partitions you have using sinfo:
+Use a partition corresponding to one specific type of GPU (e.g. h100, h200). Depending on your cluster, the default
+partition may include different GPUs that will be on different InfiniBand fabrics. See what partitions you have
+using `sinfo`:
 
 ```sh
 sinfo
 ```
 
-Then submit your sbatch script directly to Slurm, either replacing `$PARTITION` below with the name of the gpu partition you want to use, or setting it as a variable.
+Then submit your sbatch script directly to Slurm, either replacing `$PARTITION` below with the name
+of the GPU partition you want to use, or setting it as a variable.
 
-Note also that the scripts are configured by default to use 8 nodes. If you have more or less nodes, override the number of nodes by using the `-N` parameter (below we use 4 nodes).
+Note also that the scripts are configured by default to use 8 nodes. If you have more or less nodes,
+override the number of nodes by using the `-N` parameter (below we use 4 nodes).
 
 ```sh
 sbatch --partition="$PARTITION" -N 4 nccl-test-distributed-h100-64.slurm
 ```
 
-The output will be put into a file of the form `nccl_test_allreduce_jobID.out`. You can check on job progress using the command:
+The output will be put into a file of the form `nccl_test_allreduce_jobID.out`.
+You can check on job progress using the command:
 
 ```sh
 tail -f nccl_test_allreduce_*.out
@@ -30,4 +35,4 @@ There are a few practices illustrated by these sbatch scripts that we recommend 
 
 - Organize job output by job ID. If there is an error, we can use the job ID to quickly examine the metrics associated with the job.
 - Pull the container first and then use it from a shared directory. This will speed everything up considerably.
-- Use the environment variables here to ensure best performance.
+- Use the environment variables here to ensure optimal performance.

--- a/slurm/nccl-test-distributed-a100-64-enroot.slurm
+++ b/slurm/nccl-test-distributed-a100-64-enroot.slurm
@@ -15,13 +15,13 @@ export NCCL_SOCKET_IFNAME=eth0
 export NCCL_IB_HCA=ibp
 export UCX_NET_DEVICES=ibp0:1,ibp1:1,ibp2:1,ibp3:1
 
-# Define nccl version we will test 
+# Define nccl version we will test
 # See https://github.com/coreweave/nccl-tests/pkgs/container/nccl-tests for available tags.
 
-nccl_version="12.9.1-devel-ubuntu22.04-nccl2.27.5-1-d5a135d"
+nccl_version="12.9.1-devel-ubuntu22.04-nccl2.27.6-1-7c12c62"
 
-# Create a directory to store container images. You can change this 
-# or use an existing directory below. 
+# Create a directory to store container images. You can change this
+# or use an existing directory below.
 
 CONTAINER_DIR="$(realpath -s images)"
 mkdir -p "$CONTAINER_DIR"
@@ -31,10 +31,9 @@ if [ "$fstype" != "nfs" ] ; then
   exit 1
 fi
 
-
 # Pull the container image, if not already pulled. For large parallel jobs, this
-# will save time by not hitting the repository from each task. This will 
-# be executed once on the head node of the allocation. 
+# will save time by not hitting the repository from each task. This will
+# be executed once on the head node of the allocation.
 
 CONTAINER_IMAGE="${CONTAINER_DIR}/nccl_${nccl_version}.sqsh"
 if [ -f "$CONTAINER_IMAGE" ]; then
@@ -51,16 +50,17 @@ fi
 echo "Using nodes: $SLURM_JOB_NODELIST"
 
 # When launching a pyxis job as a non-root user you need to use --no-container-remap-root and when launching as root
-# you need to use --container-remap-root. This is becuse the container is built with Ubuntu 22.04+ and is built to use PMIx. 
+# you need to use --container-remap-root. This is because the container is built with Ubuntu 22.04+ and is built to use PMIx.
 
-if [ $(whoami) = "root" ]; then
+if [ "$(whoami)" = "root" ]; then
   cflag="--container-remap-root"
-else 
+else
   cflag="--no-container-remap-root"
 fi
 
 # The srun command inherits the SBATCH flags set above
 # and will be launched once for each task (8 tasks on each of 8 nodes).
+
 srun --container-image="$CONTAINER_IMAGE" \
-     "$cflag" --no-container-mount-home --kill-on-bad-exit=1 \
-     /opt/nccl_tests/build/all_reduce_perf -b 512M -e 8G -f 2 -g 1 
+     --mpi=pmix "$cflag" --no-container-mount-home --kill-on-bad-exit=1 \
+     /opt/nccl_tests/build/all_reduce_perf -b 512M -e 8G -f 2 -g 1

--- a/slurm/nccl-test-distributed-a100-64.slurm
+++ b/slurm/nccl-test-distributed-a100-64.slurm
@@ -9,7 +9,7 @@
 #SBATCH --exclusive # Use --exclusive to ensure no other jobs run on the same nodes
 
 
-
+. /usr/share/modules/init/bash
 module load image-defaults
 
 # NCCL environment variables are documented at:
@@ -22,4 +22,4 @@ export UCX_NET_DEVICES=ibp0:1,ibp1:1,ibp2:1,ibp3:1
 # Log the assigned nodes
 echo "Using nodes: $SLURM_JOB_NODELIST"
 
-srun  --kill-on-bad-exit=1 /opt/nccl_tests/build/all_reduce_perf -b 512M -e 8G -f 2 -g 1
+srun --mpi=pmix --kill-on-bad-exit=1 /opt/nccl_tests/build/all_reduce_perf -b 512M -e 8G -f 2 -g 1

--- a/slurm/nccl-test-distributed-gb200-nvl72-enroot.slurm
+++ b/slurm/nccl-test-distributed-gb200-nvl72-enroot.slurm
@@ -8,10 +8,10 @@
 #SBATCH --output="%x_%j.out" # Use %x for job name and %j for slurm job ID in output file name
 #SBATCH --exclusive # Use --exclusive to ensure no other jobs run on the same nodes
 
-
 # NCCL environment variables are documented at:
 # https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/env.html
-# Use these environment variables to ensure optimal infiniband performance.
+
+# Use these environment variables to ensure optimal InfiniBand performance.
 
 export NCCL_SOCKET_IFNAME=eth0
 export NCCL_IB_HCA=ibp
@@ -24,13 +24,13 @@ export NCCL_NVLS_ENABLE=0
 export NCCL_NET_GDR_C2C=1
 export PMIX_MCA_gds='^ds12'
 
-# Define nccl version we will test 
+# Define nccl version we will test
 # See https://github.com/coreweave/nccl-tests/pkgs/container/nccl-tests for available tags.
 
-nccl_version="12.9.1-devel-ubuntu22.04-nccl2.27.5-1-d5a135d"
+nccl_version="12.9.1-devel-ubuntu22.04-nccl2.27.6-1-7c12c62"
 
-# Create a directory to store container images. You can change this 
-# or use an existing directory below. 
+# Create a directory to store container images. You can change this
+# or use an existing directory below.
 
 CONTAINER_DIR="$(realpath -s images)"
 mkdir -p "$CONTAINER_DIR"
@@ -41,8 +41,8 @@ if [ "$fstype" != "nfs" ] ; then
 fi
 
 # Pull the container image, if not already pulled. For large parallel jobs, this
-# will save time by not hitting the repository from each task. This will 
-# be executed once on the head node of the allocation. 
+# will save time by not hitting the repository from each task. This will
+# be executed once on the head node of the allocation.
 
 CONTAINER_IMAGE="${CONTAINER_DIR}/nccl_${nccl_version}.sqsh"
 if [ -f "$CONTAINER_IMAGE" ]; then
@@ -59,11 +59,11 @@ fi
 echo "Using nodes: $SLURM_JOB_NODELIST"
 
 # When launching a pyxis job as a non-root user you need to use --no-container-remap-root and when launching as root
-# you need to use --container-remap-root. This is becuse the container is built with Ubuntu 22.04+ and is built to use PMIx. 
+# you need to use --container-remap-root. This is because the container is built with Ubuntu 22.04+ and is built to use PMIx.
 
-if [ $(whoami) = "root" ]; then
+if [ "$(whoami)" = "root" ]; then
   cflag="--container-remap-root"
-else 
+else
   cflag="--no-container-remap-root"
 fi
 
@@ -71,6 +71,5 @@ fi
 # and will be launched once for each task.
 
 srun --container-image="$CONTAINER_IMAGE" \
-     --mpi=pmix "$cflag" --kill-on-bad-exit=1 --container-mount-home \
+     --mpi=pmix "$cflag" --no-container-mount-home --kill-on-bad-exit=1 \
      /opt/nccl_tests/build/all_reduce_perf -b 512M -e 8G -f 2 -g 1
-

--- a/slurm/nccl-test-distributed-h100-64-enroot-sharp.slurm
+++ b/slurm/nccl-test-distributed-h100-64-enroot-sharp.slurm
@@ -8,28 +8,30 @@
 #SBATCH --output="%x_%j.out" # Use %x for job name and %j for slurm job ID in output file name
 #SBATCH --exclusive # Use --exclusive to ensure no other jobs run on the same nodes
 
-
 # NCCL environment variables are documented at:
 # https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/env.html
 
-# Use these environment variables to ensure optimal infiniband performance when SHARP is enabled.
+# Use these environment variables to ensure optimal InfiniBand performance when SHARP is enabled.
+
 export NCCL_SOCKET_IFNAME=eth0
 export NCCL_IB_HCA=ibp
 export UCX_NET_DEVICES=ibp0:1,ibp1:1,ibp2:1,ibp3:1,ibp4:1,ibp5:1,ibp6:1,ibp7:1
 export SHARP_COLL_ENABLE_PCI_RELAXED_ORDERING=1
+export PMIX_MCA_gds='^ds12'
 
 # Dynamic Connections can be forced as transport
 export UCX_TLS=dc,self
 
 # Enable network collections
 export NCCL_COLLNET_ENABLE=1
-# Define nccl version we will test 
+
+# Define nccl version we will test
 # See https://github.com/coreweave/nccl-tests/pkgs/container/nccl-tests for available tags.
 
-nccl_version="12.9.1-devel-ubuntu22.04-nccl2.27.5-1-d5a135d"
+nccl_version="12.9.1-devel-ubuntu22.04-nccl2.27.6-1-7c12c62"
 
-# Create a directory to store container images. You can change this 
-# or use an existing directory below. 
+# Create a directory to store container images. You can change this
+# or use an existing directory below.
 
 CONTAINER_DIR="$(realpath -s images)"
 mkdir -p "$CONTAINER_DIR"
@@ -39,10 +41,9 @@ if [ "$fstype" != "nfs" ] ; then
   exit 1
 fi
 
-
 # Pull the container image, if not already pulled. For large parallel jobs, this
-# will save time by not hitting the repository from each task. This will 
-# be executed once on the head node of the allocation. 
+# will save time by not hitting the repository from each task. This will
+# be executed once on the head node of the allocation.
 
 CONTAINER_IMAGE="${CONTAINER_DIR}/nccl_${nccl_version}.sqsh"
 if [ -f "$CONTAINER_IMAGE" ]; then
@@ -55,18 +56,15 @@ else
    fi
 fi
 
-
-
-
 # Log the assigned nodes
 echo "Using nodes: $SLURM_JOB_NODELIST"
 
 # When launching a pyxis job as a non-root user you need to use --no-container-remap-root and when launching as root
-# you need to use --container-remap-root. This is becuse the container is built with Ubuntu 22.04+ and is built to use PMIx. 
+# you need to use --container-remap-root. This is because the container is built with Ubuntu 22.04+ and is built to use PMIx.
 
-if [ $(whoami) = "root" ]; then
+if [ "$(whoami)" = "root" ]; then
   cflag="--container-remap-root"
-else 
+else
   cflag="--no-container-remap-root"
 fi
 
@@ -74,5 +72,5 @@ fi
 # and will be launched once for each task (8 tasks on each of 8 nodes).
 
 srun --container-image="$CONTAINER_IMAGE" \
-     "$cflag" --no-container-mount-home --kill-on-bad-exit=1 \
+     --mpi=pmix "$cflag" --no-container-mount-home --kill-on-bad-exit=1 \
      /opt/nccl_tests/build/all_reduce_perf -b 512M -e 8G -f 2 -g 1

--- a/slurm/nccl-test-distributed-h100-64-enroot.slurm
+++ b/slurm/nccl-test-distributed-h100-64-enroot.slurm
@@ -8,26 +8,25 @@
 #SBATCH --output="%x_%j.out" # Use %x for job name and %j for slurm job ID in output file name
 #SBATCH --exclusive # Use --exclusive to ensure no other jobs run on the same nodes
 
-
 # NCCL environment variables are documented at:
 # https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/env.html
 
-# Use these environment variables to ensure optimal infiniband performance.
+# Use these environment variables to ensure optimal InfiniBand performance.
 
 export NCCL_SOCKET_IFNAME=eth0
 export NCCL_IB_HCA=ibp
 export UCX_NET_DEVICES=ibp0:1,ibp1:1,ibp2:1,ibp3:1,ibp4:1,ibp5:1,ibp6:1,ibp7:1
 export SHARP_COLL_ENABLE_PCI_RELAXED_ORDERING=1
 export NCCL_COLLNET_ENABLE=0
-export PMIX_MCA_gds=hash # not strictly needed but prevents harmless PMIX errors with gds_ds12_lock_pthread
+export PMIX_MCA_gds='^ds12'
 
-# Define nccl version we will test 
+# Define nccl version we will test
 # See https://github.com/coreweave/nccl-tests/pkgs/container/nccl-tests for available tags.
 
-nccl_version="12.9.1-devel-ubuntu22.04-nccl2.27.5-1-d5a135d"
+nccl_version="12.9.1-devel-ubuntu22.04-nccl2.27.6-1-7c12c62"
 
-# Create a directory to store container images. You can change this 
-# or use an existing directory below. 
+# Create a directory to store container images. You can change this
+# or use an existing directory below.
 
 CONTAINER_DIR="$(realpath -s images)"
 mkdir -p "$CONTAINER_DIR"
@@ -37,10 +36,9 @@ if [ "$fstype" != "nfs" ] ; then
   exit 1
 fi
 
-
 # Pull the container image, if not already pulled. For large parallel jobs, this
-# will save time by not hitting the repository from each task. This will 
-# be executed once on the head node of the allocation. 
+# will save time by not hitting the repository from each task. This will
+# be executed once on the head node of the allocation.
 
 CONTAINER_IMAGE="${CONTAINER_DIR}/nccl_${nccl_version}.sqsh"
 if [ -f "$CONTAINER_IMAGE" ]; then
@@ -53,23 +51,21 @@ else
    fi
 fi
 
-
 # Log the assigned nodes
 echo "Using nodes: $SLURM_JOB_NODELIST"
 
 # When launching a pyxis job as a non-root user you need to use --no-container-remap-root and when launching as root
-# you need to use --container-remap-root. This is because the container is built with Ubuntu 22.04+ and is built to use PMIx. 
+# you need to use --container-remap-root. This is because the container is built with Ubuntu 22.04+ and is built to use PMIx.
 
-if [ $(whoami) = "root" ]; then
+if [ "$(whoami)" = "root" ]; then
   cflag="--container-remap-root"
-else 
+else
   cflag="--no-container-remap-root"
 fi
 
 # The srun command inherits the SBATCH flags set above
 # and will be launched once for each task (8 tasks on each of 8 nodes).
 
-
 srun --container-image="$CONTAINER_IMAGE" \
-     "$cflag" --no-container-mount-home --kill-on-bad-exit=1 \
+     --mpi=pmix "$cflag" --no-container-mount-home --kill-on-bad-exit=1 \
      /opt/nccl_tests/build/all_reduce_perf -b 512M -e 8G -f 2 -g 1

--- a/slurm/nccl-test-distributed-h100-64.slurm
+++ b/slurm/nccl-test-distributed-h100-64.slurm
@@ -9,6 +9,7 @@
 #SBATCH --exclusive # Use --exclusive to ensure no other jobs run on the same nodes
 
 
+. /usr/share/modules/init/bash
 module load image-defaults
 
 # NCCL environment variables are documented at:
@@ -29,4 +30,4 @@ export NCCL_COLLNET_ENABLE=0
 # Log the assigned nodes
 echo "Using nodes: $SLURM_JOB_NODELIST"
 
-srun --kill-on-bad-exit=1 /opt/nccl_tests/build/all_reduce_perf -b 512M -e 8G -f 2 -g 1
+srun --mpi=pmix --kill-on-bad-exit=1 /opt/nccl_tests/build/all_reduce_perf -b 512M -e 8G -f 2 -g 1


### PR DESCRIPTION
# Fixes for `slurm` scripts

This is a collection of fixes written for PR #53. It mainly changes the scripts to use more consistent environment variables and `srun` flags, updates the included image tags, fixes usage of the `module load` command, quotes more shell variables, and fixes some formatting inconsistencies, typos, and so on.