### PR TITLE
feat: Update to NCCL 2.27.7-1

### DIFF
--- a/.github/workflows/ubuntu-20.yml
+++ b/.github/workflows/ubuntu-20.yml
@@ -21,7 +21,7 @@ jobs:
       base-image: nvidia/cuda
       base-tag: 12.2.2-devel-ubuntu20.04
       cuda-version: "12.2.2"
-      nccl-version: 2.27.6-1
+      nccl-version: 2.27.7-1
       cuda-samples-version: "12.2"
       hpcx-distribution: "hpcx-v2.23-gcc-doca_ofed-ubuntu20.04-cuda12"
 
@@ -39,7 +39,7 @@ jobs:
       base-image: nvidia/cuda
       base-tag: 12.4.1-devel-ubuntu20.04
       cuda-version: "12.4.1"
-      nccl-version: 2.27.6-1
+      nccl-version: 2.27.7-1
       cuda-samples-version: "12.4"
       hpcx-distribution: "hpcx-v2.23-gcc-doca_ofed-ubuntu20.04-cuda12"
 
@@ -57,7 +57,7 @@ jobs:
       base-image: nvidia/cuda
       base-tag: 12.6.3-devel-ubuntu20.04
       cuda-version: "12.6.3"
-      nccl-version: 2.27.6-1
+      nccl-version: 2.27.7-1
       cuda-samples-version: "12.5"
       hpcx-distribution: "hpcx-v2.23-gcc-doca_ofed-ubuntu20.04-cuda12"
 
@@ -75,7 +75,7 @@ jobs:
       base-image: nvidia/cuda
       base-tag: 12.8.1-devel-ubuntu20.04
       cuda-version: "12.8.1"
-      nccl-version: 2.27.6-1
+      nccl-version: 2.27.7-1
       cuda-samples-version: "12.5"
       hpcx-distribution: "hpcx-v2.23-gcc-doca_ofed-ubuntu20.04-cuda12"
 
@@ -93,6 +93,6 @@ jobs:
       base-image: nvidia/cuda
       base-tag: 12.9.1-devel-ubuntu20.04
       cuda-version: "12.9.1"
-      nccl-version: 2.27.6-1
+      nccl-version: 2.27.7-1
       cuda-samples-version: "12.5"
       hpcx-distribution: "hpcx-v2.23-gcc-doca_ofed-ubuntu20.04-cuda12"

--- a/.github/workflows/ubuntu-22.yml
+++ b/.github/workflows/ubuntu-22.yml
@@ -21,7 +21,7 @@ jobs:
       base-image: nvidia/cuda
       base-tag: 12.2.2-devel-ubuntu22.04
       cuda-version: "12.2.2"
-      nccl-version: 2.27.6-1
+      nccl-version: 2.27.7-1
       cuda-samples-version: "12.2"
       hpcx-distribution: "hpcx-v2.23-gcc-doca_ofed-ubuntu22.04-cuda12"
 
@@ -39,7 +39,7 @@ jobs:
       base-image: nvidia/cuda
       base-tag: 12.4.1-devel-ubuntu22.04
       cuda-version: "12.4.1"
-      nccl-version: 2.27.6-1
+      nccl-version: 2.27.7-1
       cuda-samples-version: "12.4"
       hpcx-distribution: "hpcx-v2.23-gcc-doca_ofed-ubuntu22.04-cuda12"
 
@@ -57,7 +57,7 @@ jobs:
       base-image: nvidia/cuda
       base-tag: 12.6.3-devel-ubuntu22.04
       cuda-version: "12.6.3"
-      nccl-version: 2.27.6-1
+      nccl-version: 2.27.7-1
       cuda-samples-version: "12.5"
       hpcx-distribution: "hpcx-v2.23-gcc-doca_ofed-ubuntu22.04-cuda12"
 
@@ -75,7 +75,7 @@ jobs:
       base-image: nvidia/cuda
       base-tag: 12.8.1-devel-ubuntu22.04
       cuda-version: "12.8.1"
-      nccl-version: 2.27.6-1
+      nccl-version: 2.27.7-1
       cuda-samples-version: "12.5"
       hpcx-distribution: "hpcx-v2.23-gcc-doca_ofed-ubuntu22.04-cuda12"
 
@@ -93,6 +93,6 @@ jobs:
       base-image: nvidia/cuda
       base-tag: 12.9.1-devel-ubuntu22.04
       cuda-version: "12.9.1"
-      nccl-version: 2.27.6-1
+      nccl-version: 2.27.7-1
       cuda-samples-version: "12.5"
       hpcx-distribution: "hpcx-v2.23-gcc-doca_ofed-ubuntu22.04-cuda12"

--- a/Dockerfile.ubuntu20
+++ b/Dockerfile.ubuntu20
@@ -58,7 +58,7 @@ RUN apt-get -qq update && \
 
 FROM builder-base AS libnccl2
 # NCCL
-ARG TARGET_NCCL_VERSION='2.27.6-1'
+ARG TARGET_NCCL_VERSION='2.27.7-1'
 ARG CUDA_ARCH_LIST='70 80 89 90 100 120'
 # Converts CUDA_ARCH_LIST to '-gencode=arch=compute_XX,code=sm_XX -gencode=...' format with PTX for the last listed arch
 RUN case "${CUDA_VERSION}" in 12.[0-7].*) \

--- a/Dockerfile.ubuntu22
+++ b/Dockerfile.ubuntu22
@@ -58,7 +58,7 @@ RUN apt-get -qq update && \
 
 FROM builder-base AS libnccl2
 # NCCL
-ARG TARGET_NCCL_VERSION='2.27.6-1'
+ARG TARGET_NCCL_VERSION='2.27.7-1'
 ARG CUDA_ARCH_LIST='70 80 89 90 100 120'
 # Converts CUDA_ARCH_LIST to '-gencode=arch=compute_XX,code=sm_XX -gencode=...' format with PTX for the last listed arch
 RUN case "${CUDA_VERSION}" in 12.[0-7].*) \

--- a/README.md
+++ b/README.md
@@ -64,22 +64,22 @@ the following components:
 CoreWeave
 also [publishes images](https://github.com/coreweave/nccl-tests/pkgs/container/nccl-tests)
 built from these Dockerfiles that can be used as base for your own images.  
-The images below include **NCCL v2.27.6-1**, **HPC-X v2.23**, and **cuDNN v9.10.2.21-1**.  
+The images below include **NCCL v2.27.7-1**, **HPC-X v2.23**, and **cuDNN v9.10.2.21-1**.  
 Each image is multi-arch, and can be used for both `linux/amd64` and `linux/arm64` containers.
 Compute capabilities up to Blackwell (10.0) are supported.
 
 | **Image Tag**                                                              | **Ubuntu** | **CUDA** |
 |----------------------------------------------------------------------------|------------|----------|
-| ghcr.io/coreweave/nccl-tests:12.9.1-devel-ubuntu22.04-nccl2.27.6-1-7c12c62 | 22.04      | 12.9.1   |
-| ghcr.io/coreweave/nccl-tests:12.8.1-devel-ubuntu22.04-nccl2.27.6-1-7c12c62 | 22.04      | 12.8.1   |
-| ghcr.io/coreweave/nccl-tests:12.6.3-devel-ubuntu22.04-nccl2.27.6-1-7c12c62 | 22.04      | 12.6.3   |
-| ghcr.io/coreweave/nccl-tests:12.4.1-devel-ubuntu22.04-nccl2.27.6-1-7c12c62 | 22.04      | 12.4.1   |
-| ghcr.io/coreweave/nccl-tests:12.2.2-devel-ubuntu22.04-nccl2.27.6-1-7c12c62 | 22.04      | 12.2.2   |
-| ghcr.io/coreweave/nccl-tests:12.9.1-devel-ubuntu20.04-nccl2.27.6-1-7c12c62 | 20.04      | 12.9.1   |
-| ghcr.io/coreweave/nccl-tests:12.8.1-devel-ubuntu20.04-nccl2.27.6-1-7c12c62 | 20.04      | 12.8.1   |
-| ghcr.io/coreweave/nccl-tests:12.6.3-devel-ubuntu20.04-nccl2.27.6-1-7c12c62 | 20.04      | 12.6.3   |
-| ghcr.io/coreweave/nccl-tests:12.4.1-devel-ubuntu20.04-nccl2.27.6-1-7c12c62 | 20.04      | 12.4.1   |
-| ghcr.io/coreweave/nccl-tests:12.2.2-devel-ubuntu20.04-nccl2.27.6-1-7c12c62 | 20.04      | 12.2.2   |
+| ghcr.io/coreweave/nccl-tests:12.9.1-devel-ubuntu22.04-nccl2.27.7-1-13b2c72 | 22.04      | 12.9.1   |
+| ghcr.io/coreweave/nccl-tests:12.8.1-devel-ubuntu22.04-nccl2.27.7-1-13b2c72 | 22.04      | 12.8.1   |
+| ghcr.io/coreweave/nccl-tests:12.6.3-devel-ubuntu22.04-nccl2.27.7-1-13b2c72 | 22.04      | 12.6.3   |
+| ghcr.io/coreweave/nccl-tests:12.4.1-devel-ubuntu22.04-nccl2.27.7-1-13b2c72 | 22.04      | 12.4.1   |
+| ghcr.io/coreweave/nccl-tests:12.2.2-devel-ubuntu22.04-nccl2.27.7-1-13b2c72 | 22.04      | 12.2.2   |
+| ghcr.io/coreweave/nccl-tests:12.9.1-devel-ubuntu20.04-nccl2.27.7-1-13b2c72 | 20.04      | 12.9.1   |
+| ghcr.io/coreweave/nccl-tests:12.8.1-devel-ubuntu20.04-nccl2.27.7-1-13b2c72 | 20.04      | 12.8.1   |
+| ghcr.io/coreweave/nccl-tests:12.6.3-devel-ubuntu20.04-nccl2.27.7-1-13b2c72 | 20.04      | 12.6.3   |
+| ghcr.io/coreweave/nccl-tests:12.4.1-devel-ubuntu20.04-nccl2.27.7-1-13b2c72 | 20.04      | 12.4.1   |
+| ghcr.io/coreweave/nccl-tests:12.2.2-devel-ubuntu20.04-nccl2.27.7-1-13b2c72 | 20.04      | 12.2.2   |
 
 ## Running NCCL Tests
 


### PR DESCRIPTION
# NCCL v2.27.7-1

This change updates NCCL to version [2.27.7-1](https://github.com/NVIDIA/nccl/releases/tag/v2.27.7-1), up from [2.27.6-1](https://github.com/NVIDIA/nccl/releases/tag/v2.27.6-1).