### PR TITLE
feat: test acutal real world msg size

### DIFF
--- a/slurm/nccl-test-distributed-a100-64-enroot.slurm
+++ b/slurm/nccl-test-distributed-a100-64-enroot.slurm
@@ -63,4 +63,4 @@ fi
 
 srun --container-image="$CONTAINER_IMAGE" \
      --mpi=pmix "$cflag" --no-container-mount-home --kill-on-bad-exit=1 \
-     /opt/nccl_tests/build/all_reduce_perf -b 512M -e 8G -f 2 -g 1
+     /opt/nccl_tests/build/all_reduce_perf -b 16M -e 8G -f 2 -g 1

--- a/slurm/nccl-test-distributed-a100-64.slurm
+++ b/slurm/nccl-test-distributed-a100-64.slurm
@@ -22,4 +22,4 @@ export UCX_NET_DEVICES=ibp0:1,ibp1:1,ibp2:1,ibp3:1
 # Log the assigned nodes
 echo "Using nodes: $SLURM_JOB_NODELIST"
 
-srun --mpi=pmix --kill-on-bad-exit=1 /opt/nccl_tests/build/all_reduce_perf -b 512M -e 8G -f 2 -g 1
+srun --mpi=pmix --kill-on-bad-exit=1 /opt/nccl_tests/build/all_reduce_perf -b 16M -e 8G -f 2 -g 1

--- a/slurm/nccl-test-distributed-gb200-nvl72-enroot.slurm
+++ b/slurm/nccl-test-distributed-gb200-nvl72-enroot.slurm
@@ -73,4 +73,4 @@ fi
 
 srun --container-image="$CONTAINER_IMAGE" \
      --mpi=pmix "$cflag" --no-container-mount-home --kill-on-bad-exit=1 \
-     /opt/nccl_tests/build/all_reduce_perf -b 512M -e 8G -f 2 -g 1
+     /opt/nccl_tests/build/all_reduce_perf -b 16M -e 8G -f 2 -g 1

--- a/slurm/nccl-test-distributed-h100-64-enroot-sharp.slurm
+++ b/slurm/nccl-test-distributed-h100-64-enroot-sharp.slurm
@@ -73,4 +73,4 @@ fi
 
 srun --container-image="$CONTAINER_IMAGE" \
      --mpi=pmix "$cflag" --no-container-mount-home --kill-on-bad-exit=1 \
-     /opt/nccl_tests/build/all_reduce_perf -b 512M -e 8G -f 2 -g 1
+     /opt/nccl_tests/build/all_reduce_perf -b 16M -e 8G -f 2 -g 1

--- a/slurm/nccl-test-distributed-h100-64-enroot.slurm
+++ b/slurm/nccl-test-distributed-h100-64-enroot.slurm
@@ -68,4 +68,4 @@ fi
 
 srun --container-image="$CONTAINER_IMAGE" \
      --mpi=pmix "$cflag" --no-container-mount-home --kill-on-bad-exit=1 \
-     /opt/nccl_tests/build/all_reduce_perf -b 512M -e 8G -f 2 -g 1
+     /opt/nccl_tests/build/all_reduce_perf -b 16M -e 8G -f 2 -g 1

--- a/slurm/nccl-test-distributed-h100-64.slurm
+++ b/slurm/nccl-test-distributed-h100-64.slurm
@@ -30,4 +30,4 @@ export NCCL_COLLNET_ENABLE=0
 # Log the assigned nodes
 echo "Using nodes: $SLURM_JOB_NODELIST"
 
-srun --mpi=pmix --kill-on-bad-exit=1 /opt/nccl_tests/build/all_reduce_perf -b 512M -e 8G -f 2 -g 1
+srun --mpi=pmix --kill-on-bad-exit=1 /opt/nccl_tests/build/all_reduce_perf -b 16M -e 8G -f 2 -g 1


### PR DESCRIPTION
real world world training and inference sizes is never near 512MiB, real world is between 16MiB to 256MiB for DDP/TP/FSDP/etc