### PR TITLE
Update environment variables and job settings to latest best practice

### DIFF
--- a/mpi-operator/nccl-test-distributed-a100-64-gdrcopy-mpijob.yaml
+++ b/mpi-operator/nccl-test-distributed-a100-64-gdrcopy-mpijob.yaml
@@ -12,7 +12,7 @@ spec:
       template:
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:12.8.1-devel-ubuntu22.04-nccl2.26.2-1-0708d2e
+            - image: ghcr.io/coreweave/nccl-tests:12.9.1-devel-ubuntu22.04-nccl2.28.3-1-8b67957
               name: nccl
               env:
                 - name: OMPI_ALLOW_RUN_AS_ROOT
@@ -43,7 +43,7 @@ spec:
       template:
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:12.8.1-devel-ubuntu22.04-nccl2.26.2-1-0708d2e
+            - image: ghcr.io/coreweave/nccl-tests:12.9.1-devel-ubuntu22.04-nccl2.28.3-1-8b67957
               name: nccl
               resources:
                 requests:

--- a/mpi-operator/nccl-test-distributed-a100-64-mpijob.yaml
+++ b/mpi-operator/nccl-test-distributed-a100-64-mpijob.yaml
@@ -12,7 +12,7 @@ spec:
       template:
           spec:
             containers:
-            - image: ghcr.io/coreweave/nccl-tests:12.8.1-devel-ubuntu22.04-nccl2.26.2-1-0708d2e
+            - image: ghcr.io/coreweave/nccl-tests:12.9.1-devel-ubuntu22.04-nccl2.28.3-1-8b67957
               name: nccl
               env:
               - name: OMPI_ALLOW_RUN_AS_ROOT
@@ -43,7 +43,7 @@ spec:
           metadata.coreweave.cloud/job: nccl-test
         spec:
           containers:
-          - image: ghcr.io/coreweave/nccl-tests:12.8.1-devel-ubuntu22.04-nccl2.26.2-1-0708d2e
+          - image: ghcr.io/coreweave/nccl-tests:12.9.1-devel-ubuntu22.04-nccl2.28.3-1-8b67957
             name: nccl
             resources:
               requests:

--- a/mpi-operator/nccl-test-distributed-a100-64-noib-mpijob.yaml
+++ b/mpi-operator/nccl-test-distributed-a100-64-noib-mpijob.yaml
@@ -12,7 +12,7 @@ spec:
       template:
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:12.8.1-devel-ubuntu22.04-nccl2.26.2-1-0708d2e
+            - image: ghcr.io/coreweave/nccl-tests:12.9.1-devel-ubuntu22.04-nccl2.28.3-1-8b67957
               name: nccl
               env:
                 - name: OMPI_ALLOW_RUN_AS_ROOT
@@ -45,7 +45,7 @@ spec:
           metadata.coreweave.cloud/job: nccl-test
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:12.8.1-devel-ubuntu22.04-nccl2.26.2-1-0708d2e
+            - image: ghcr.io/coreweave/nccl-tests:12.9.1-devel-ubuntu22.04-nccl2.28.3-1-8b67957
               name: nccl
               resources:
                 requests:

--- a/mpi-operator/nccl-test-distributed-a100-64-sharp-mpijob.yaml
+++ b/mpi-operator/nccl-test-distributed-a100-64-sharp-mpijob.yaml
@@ -12,7 +12,7 @@ spec:
       template:
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:12.8.1-devel-ubuntu22.04-nccl2.26.2-1-0708d2e
+            - image: ghcr.io/coreweave/nccl-tests:12.9.1-devel-ubuntu22.04-nccl2.28.3-1-8b67957
               name: nccl
               env:
                 - name: OMPI_ALLOW_RUN_AS_ROOT
@@ -47,7 +47,7 @@ spec:
           metadata.coreweave.cloud/job: nccl-test
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:12.8.1-devel-ubuntu22.04-nccl2.26.2-1-0708d2e
+            - image: ghcr.io/coreweave/nccl-tests:12.9.1-devel-ubuntu22.04-nccl2.28.3-1-8b67957
               name: nccl
               resources:
                 requests:

--- a/mpi-operator/nccl-test-distributed-gb200-nvl72-mpijob.yaml
+++ b/mpi-operator/nccl-test-distributed-gb200-nvl72-mpijob.yaml
@@ -14,7 +14,7 @@ spec:
       template:
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:12.8.1-devel-ubuntu22.04-nccl2.26.2-1-0708d2e
+            - image: ghcr.io/coreweave/nccl-tests:12.9.1-devel-ubuntu22.04-nccl2.28.3-1-8b67957
               name: nccl
               env:
                 - name: OMPI_ALLOW_RUN_AS_ROOT
@@ -53,7 +53,7 @@ spec:
           metadata.coreweave.cloud/job: nccl-test
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:12.8.1-devel-ubuntu22.04-nccl2.26.2-1-0708d2e
+            - image: ghcr.io/coreweave/nccl-tests:12.9.1-devel-ubuntu22.04-nccl2.28.3-1-8b67957
               name: nccl
               resources:
                 requests:

--- a/mpi-operator/nccl-test-distributed-h100-64-mpijob.yaml
+++ b/mpi-operator/nccl-test-distributed-h100-64-mpijob.yaml
@@ -12,7 +12,7 @@ spec:
       template:
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:12.8.1-devel-ubuntu22.04-nccl2.26.2-1-0708d2e
+            - image: ghcr.io/coreweave/nccl-tests:12.9.1-devel-ubuntu22.04-nccl2.28.3-1-8b67957
               name: nccl
               env:
                 - name: OMPI_ALLOW_RUN_AS_ROOT
@@ -47,7 +47,7 @@ spec:
           metadata.coreweave.cloud/job: nccl-test
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:12.8.1-devel-ubuntu22.04-nccl2.26.2-1-0708d2e
+            - image: ghcr.io/coreweave/nccl-tests:12.9.1-devel-ubuntu22.04-nccl2.28.3-1-8b67957
               name: nccl
               resources:
                 requests:

--- a/mpi-operator/nccl-test-distributed-h100-64-sharp-mpijob.yaml
+++ b/mpi-operator/nccl-test-distributed-h100-64-sharp-mpijob.yaml
@@ -12,7 +12,7 @@ spec:
       template:
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:12.8.1-devel-ubuntu22.04-nccl2.26.2-1-0708d2e
+            - image: ghcr.io/coreweave/nccl-tests:12.9.1-devel-ubuntu22.04-nccl2.28.3-1-8b67957
               name: nccl
               env:
                 - name: OMPI_ALLOW_RUN_AS_ROOT
@@ -48,7 +48,7 @@ spec:
           metadata.coreweave.cloud/job: nccl-test
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:12.8.1-devel-ubuntu22.04-nccl2.26.2-1-0708d2e
+            - image: ghcr.io/coreweave/nccl-tests:12.9.1-devel-ubuntu22.04-nccl2.28.3-1-8b67957
               name: nccl
               resources:
                 requests:

--- a/slurm/nccl-test-distributed-a100-64-enroot.slurm
+++ b/slurm/nccl-test-distributed-a100-64-enroot.slurm
@@ -18,7 +18,7 @@ export UCX_NET_DEVICES=ibp0:1,ibp1:1,ibp2:1,ibp3:1
 # Define nccl version we will test
 # See https://github.com/coreweave/nccl-tests/pkgs/container/nccl-tests for available tags.
 
-nccl_version="12.9.1-devel-ubuntu22.04-nccl2.27.6-1-7c12c62"
+nccl_version="12.9.1-devel-ubuntu22.04-nccl2.28.3-1-8b67957"
 
 # Create a directory to store container images. You can change this
 # or use an existing directory below.

--- a/slurm/nccl-test-distributed-gb200-nvl72-enroot.slurm
+++ b/slurm/nccl-test-distributed-gb200-nvl72-enroot.slurm
@@ -39,7 +39,7 @@ export PMIX_MCA_gds='^ds12'
 # Define nccl version we will test
 # See https://github.com/coreweave/nccl-tests/pkgs/container/nccl-tests for available tags.
 
-nccl_version="12.9.1-devel-ubuntu22.04-nccl2.27.6-1-7c12c62"
+nccl_version="12.9.1-devel-ubuntu22.04-nccl2.28.3-1-8b67957"
 
 # Create a directory to store container images. You can change this
 # or use an existing directory below.

--- a/slurm/nccl-test-distributed-gb200-nvl72-enroot.slurm
+++ b/slurm/nccl-test-distributed-gb200-nvl72-enroot.slurm
@@ -4,25 +4,36 @@
 #SBATCH --nodes=18
 #SBATCH --ntasks-per-node=4
 #SBATCH --gpus-per-node=4
+#SBATCH --cpus-per-task=8
+#SBATCH --mem=128GB
 #SBATCH --time=20:00
 #SBATCH --output="%x_%j.out" # Use %x for job name and %j for slurm job ID in output file name
 #SBATCH --exclusive # Use --exclusive to ensure no other jobs run on the same nodes
 
 # NCCL environment variables are documented at:
 # https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/env.html
-
-# Use these environment variables to ensure optimal InfiniBand performance.
+# Out Of Band is set to run over front-end ethernet.
+# Backend is restricted to use ibp* interfaces to ensure it doesn't try to use any RoCE interfaces from the frontend.
 
 export NCCL_SOCKET_IFNAME=eth0
 export NCCL_IB_HCA=ibp
-export UCX_NET_DEVICES=ibp0:1,ibp1:1,ibp2:1,ibp3:1
-export SHARP_COLL_ENABLE_PCI_RELAXED_ORDERING=1
-export NCCL_COLLNET_ENABLE=0
-export OMPI_MCA_coll_hcoll_enable=0
 
+# GB200 Specific Settings
+# Enforce GB200 best practices to fail clearly if GB200 is not correctly functioning
+# Do not fall back to shared memory transport if NVLINK is down.
+# Enforce CUMEM functionality for faster buffer registrations.
 export NVIDIA_IMEX_CHANNELS=0
-export NCCL_NVLS_ENABLE=0
 export NCCL_NET_GDR_C2C=1
+export NCCL_MNNVL_ENABLE=1
+export NCCL_CUMEM_ENABLE=1
+export NCCL_SHM_DISABLE=0
+
+# Disable UCX
+# Restrict the transport layer for UCX, it tries to use all transports by default, this forces it on TCP. NCCL does not use UCX at all.
+# We explictly deactivate it to avoid initializing UCX by mistake as it can lead to crashes.
+export UCX_TLS=tcp
+export UCX_NET_DEVICES=eth0
+export OMPI_MCA_coll_hcoll_enable=0
 export PMIX_MCA_gds='^ds12'
 
 # Define nccl version we will test

--- a/slurm/nccl-test-distributed-h100-64-enroot-sharp.slurm
+++ b/slurm/nccl-test-distributed-h100-64-enroot-sharp.slurm
@@ -33,7 +33,7 @@ export PMIX_MCA_gds='^ds12'
 # Define nccl version we will test
 # See https://github.com/coreweave/nccl-tests/pkgs/container/nccl-tests for available tags.
 
-nccl_version="12.9.1-devel-ubuntu22.04-nccl2.27.6-1-7c12c62"
+nccl_version="12.9.1-devel-ubuntu22.04-nccl2.28.3-1-8b67957"
 
 # Create a directory to store container images. You can change this
 # or use an existing directory below.

--- a/slurm/nccl-test-distributed-h100-64-enroot-sharp.slurm
+++ b/slurm/nccl-test-distributed-h100-64-enroot-sharp.slurm
@@ -4,26 +4,31 @@
 #SBATCH --nodes=8
 #SBATCH --ntasks-per-node=8
 #SBATCH --gpus-per-node=8
+#SBATCH --cpus-per-task=8
+#SBATCH --mem=128GB
 #SBATCH --time=20:00
 #SBATCH --output="%x_%j.out" # Use %x for job name and %j for slurm job ID in output file name
 #SBATCH --exclusive # Use --exclusive to ensure no other jobs run on the same nodes
 
 # NCCL environment variables are documented at:
 # https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/env.html
-
-# Use these environment variables to ensure optimal InfiniBand performance when SHARP is enabled.
+# Out Of Band is set to run over front-end ethernet.
+# Backend is restricted to use ibp* interfaces to ensure it doesn't try to use any RoCE interfaces from the frontend.
 
 export NCCL_SOCKET_IFNAME=eth0
 export NCCL_IB_HCA=ibp
-export UCX_NET_DEVICES=ibp0:1,ibp1:1,ibp2:1,ibp3:1,ibp4:1,ibp5:1,ibp6:1,ibp7:1
-export SHARP_COLL_ENABLE_PCI_RELAXED_ORDERING=1
-export PMIX_MCA_gds='^ds12'
 
-# Dynamic Connections can be forced as transport
-export UCX_TLS=dc,self
-
-# Enable network collections
+# SHARP Related Settings
 export NCCL_COLLNET_ENABLE=1
+export SHARP_COLL_ENABLE_PCI_RELAXED_ORDERING=1
+
+# Disable UCX
+# Restrict the transport layer for UCX, it tries to use all transports by default, this forces it on TCP. NCCL does not use UCX at all.
+# We explictly deactivate it to avoid initializing UCX by mistake as it can lead to crashes.
+export UCX_TLS=tcp
+export UCX_NET_DEVICES=eth0
+export OMPI_MCA_coll_hcoll_enable=0
+export PMIX_MCA_gds='^ds12'
 
 # Define nccl version we will test
 # See https://github.com/coreweave/nccl-tests/pkgs/container/nccl-tests for available tags.

--- a/slurm/nccl-test-distributed-h100-64-enroot.slurm
+++ b/slurm/nccl-test-distributed-h100-64-enroot.slurm
@@ -29,7 +29,7 @@ export PMIX_MCA_gds='^ds12'
 # Define nccl version we will test
 # See https://github.com/coreweave/nccl-tests/pkgs/container/nccl-tests for available tags.
 
-nccl_version="12.9.1-devel-ubuntu22.04-nccl2.27.6-1-7c12c62"
+nccl_version="12.9.1-devel-ubuntu22.04-nccl2.28.3-1-8b67957"
 
 # Create a directory to store container images. You can change this
 # or use an existing directory below.

--- a/slurm/nccl-test-distributed-h100-64-enroot.slurm
+++ b/slurm/nccl-test-distributed-h100-64-enroot.slurm
@@ -4,20 +4,26 @@
 #SBATCH --nodes=8
 #SBATCH --ntasks-per-node=8
 #SBATCH --gpus-per-node=8
+#SBATCH --cpus-per-task=8
+#SBATCH --mem=128GB
 #SBATCH --time=20:00
 #SBATCH --output="%x_%j.out" # Use %x for job name and %j for slurm job ID in output file name
 #SBATCH --exclusive # Use --exclusive to ensure no other jobs run on the same nodes
 
 # NCCL environment variables are documented at:
 # https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/env.html
-
-# Use these environment variables to ensure optimal InfiniBand performance.
+# Out Of Band is set to run over front-end ethernet.
+# Backend is restricted to use ibp* interfaces to ensure it doesn't try to use any RoCE interfaces from the frontend.
 
 export NCCL_SOCKET_IFNAME=eth0
 export NCCL_IB_HCA=ibp
-export UCX_NET_DEVICES=ibp0:1,ibp1:1,ibp2:1,ibp3:1,ibp4:1,ibp5:1,ibp6:1,ibp7:1
-export SHARP_COLL_ENABLE_PCI_RELAXED_ORDERING=1
-export NCCL_COLLNET_ENABLE=0
+
+# Disable UCX
+# Restrict the transport layer for UCX, it tries to use all transports by default, this forces it on TCP. NCCL does not use UCX at all.
+# We explictly deactivate it to avoid initializing UCX by mistake as it can lead to crashes.
+export UCX_TLS=tcp
+export UCX_NET_DEVICES=eth0
+export OMPI_MCA_coll_hcoll_enable=0
 export PMIX_MCA_gds='^ds12'
 
 # Define nccl version we will test

--- a/slurm/nccl-test-distributed-h100-64.slurm
+++ b/slurm/nccl-test-distributed-h100-64.slurm
@@ -4,6 +4,8 @@
 #SBATCH --nodes=8
 #SBATCH --ntasks-per-node=8
 #SBATCH --gpus-per-node=8
+#SBATCH --cpus-per-task=8
+#SBATCH --mem=128GB
 #SBATCH --time=20:00
 #SBATCH --output="%x_%j.out" # Use %x for job name and %j for slurm job ID in output file name
 #SBATCH --exclusive # Use --exclusive to ensure no other jobs run on the same nodes
@@ -14,18 +16,19 @@ module load image-defaults
 
 # NCCL environment variables are documented at:
 # https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/env.html
+# Out Of Band is set to run over front-end ethernet.
+# Backend is restricted to use ibp* interfaces to ensure it doesn't try to use any RoCE interfaces from the frontend.
 
 export NCCL_SOCKET_IFNAME=eth0
 export NCCL_IB_HCA=ibp
-export UCX_NET_DEVICES=ibp0:1,ibp1:1,ibp2:1,ibp3:1,ibp4:1,ibp5:1,ibp6:1,ibp7:1
-export SHARP_COLL_ENABLE_PCI_RELAXED_ORDERING=1
-export NCCL_COLLNET_ENABLE=0
 
-# Relaxed ordering is fixed in NCCL 2.18.3+, but
-# in NCCL 2.18.1 and earlier it should be disabled
-# for H100s due to a bug. See:
-# https://docs.nvidia.com/deeplearning/nccl/archives/nccl_2181/release-notes/rel_2-18-1.html
-# export NCCL_IB_PCI_RELAXED_ORDERING=0
+# Disable UCX
+# Restrict the transport layer for UCX, it tries to use all transports by default, this forces it on TCP. NCCL does not use UCX at all.
+# We explictly deactivate it to avoid initializing UCX by mistake as it can lead to crashes.
+export UCX_TLS=tcp
+export UCX_NET_DEVICES=eth0
+export OMPI_MCA_coll_hcoll_enable=0
+export PMIX_MCA_gds='^ds12'
 
 # Log the assigned nodes
 echo "Using nodes: $SLURM_JOB_NODELIST"


### PR DESCRIPTION
**GB200**
Re-enable NVLS. It was disabled previously due to issues with older NCCL versions.
Enforce GB200 best practices to fail clearly if GB200 is not correctly functioning, ie do not fall back to shared memory transport if NVLINK is down. Enforce CUMEM functionality for faster buffer registrations.

**All**
Explicitly disable UCX as it is not needed by NCCL and can lead torandom crashes
Explicitly request CPU and memory from Slurm
Remove SHARP flag from non-SHARP tests as it is disabled by default


