### PR TITLE
build: Install `libcudnn9-headers` dependency for `libcudnn9-dev`

### DIFF
--- a/Dockerfile.ubuntu22
+++ b/Dockerfile.ubuntu22
@@ -8,6 +8,7 @@ ENV NV_CUDNN_VERSION='9.12.0.46-1'
 ENV NV_CUDNN_PACKAGE_NAME="libcudnn9-cuda-${CUDA_VERSION%%.*}"
 ENV NV_CUDNN_PACKAGE="libcudnn9-cuda-${CUDA_VERSION%%.*}=${NV_CUDNN_VERSION}"
 ENV NV_CUDNN_PACKAGE_DEV="libcudnn9-dev-cuda-${CUDA_VERSION%%.*}=${NV_CUDNN_VERSION}"
+ARG NV_CUDNN_PACKAGE_HEADERS="libcudnn9-headers-cuda-${CUDA_VERSION%%.*}=${NV_CUDNN_VERSION}"
 
 LABEL com.nvidia.cudnn.version="${NV_CUDNN_VERSION}"
 
@@ -15,7 +16,8 @@ RUN apt-get -qq update && \
     apt-get -qq install -y \
         --no-install-recommends \
         "${NV_CUDNN_PACKAGE}" \
-        "${NV_CUDNN_PACKAGE_DEV}" && \
+        "${NV_CUDNN_PACKAGE_DEV}" \
+        "${NV_CUDNN_PACKAGE_HEADERS}" && \
     apt-mark hold "${NV_CUDNN_PACKAGE_NAME}" && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
# Fix for installing `libcudnn9-dev`

The steps to install the `libcudnn9-dev` package changed slightly, and require `libcudnn9-headers` to be installed with it. This PR adds that package to the list of installs.