### PR TITLE
feat: Update bundled `NVIDIA/nccl-tests` & HPC-X

### DIFF
--- a/.github/workflows/ubuntu-22.yml
+++ b/.github/workflows/ubuntu-22.yml
@@ -22,7 +22,7 @@ jobs:
       base-tag: 12.6.3-devel-ubuntu22.04
       cuda-version: "12.6.3"
       nccl-version: 2.28.3-1
-      hpcx-distribution: "hpcx-v2.23-gcc-doca_ofed-ubuntu22.04-cuda12"
+      hpcx-distribution: "hpcx-v2.24-gcc-doca_ofed-ubuntu22.04-cuda12"
 
   cu128:
     uses: ./.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
       base-tag: 12.8.1-devel-ubuntu22.04
       cuda-version: "12.8.1"
       nccl-version: 2.28.3-1
-      hpcx-distribution: "hpcx-v2.23-gcc-doca_ofed-ubuntu22.04-cuda12"
+      hpcx-distribution: "hpcx-v2.24-gcc-doca_ofed-ubuntu22.04-cuda12"
 
   cu129:
     uses: ./.github/workflows/build.yml
@@ -56,7 +56,7 @@ jobs:
       base-tag: 12.9.1-devel-ubuntu22.04
       cuda-version: "12.9.1"
       nccl-version: 2.28.3-1
-      hpcx-distribution: "hpcx-v2.23-gcc-doca_ofed-ubuntu22.04-cuda12"
+      hpcx-distribution: "hpcx-v2.24-gcc-doca_ofed-ubuntu22.04-cuda12"
 
   cu130:
     uses: ./.github/workflows/build.yml

--- a/Dockerfile.ubuntu22
+++ b/Dockerfile.ubuntu22
@@ -141,7 +141,7 @@ RUN case "${CUDA_VERSION}" in 12.[0-7].*) \
 FROM builder-base AS hpcx
 # HPC-X
 # grep + sed is used as a workaround to update hardcoded pkg-config / libtools archive / CMake prefixes
-ARG HPCX_DISTRIBUTION="hpcx-v2.23-gcc-doca_ofed-ubuntu22.04-cuda12"
+ARG HPCX_DISTRIBUTION="hpcx-v2.24-gcc-doca_ofed-ubuntu22.04-cuda12"
 RUN cd /tmp && \
     DIST_NAME="${HPCX_DISTRIBUTION}-$(uname -m)" && \
     HPCX_DIR="/opt/hpcx" && \

--- a/README.md
+++ b/README.md
@@ -71,10 +71,10 @@ Compute capabilities up to Blackwell (10.0) are supported.
 
 | **Image Tag**                                                              | **Ubuntu** | **CUDA** |
 |----------------------------------------------------------------------------|------------|----------|
-| ghcr.io/coreweave/nccl-tests:13.0.0-devel-ubuntu22.04-nccl2.28.3-1-9a3fdd0 | 22.04      | 13.0.0   |
-| ghcr.io/coreweave/nccl-tests:12.9.1-devel-ubuntu22.04-nccl2.28.3-1-9a3fdd0 | 22.04      | 12.9.1   |
-| ghcr.io/coreweave/nccl-tests:12.8.1-devel-ubuntu22.04-nccl2.28.3-1-9a3fdd0 | 22.04      | 12.8.1   |
-| ghcr.io/coreweave/nccl-tests:12.6.3-devel-ubuntu22.04-nccl2.28.3-1-9a3fdd0 | 22.04      | 12.6.3   |
+| ghcr.io/coreweave/nccl-tests:13.0.0-devel-ubuntu22.04-nccl2.28.3-1-b87f806 | 22.04      | 13.0.0   |
+| ghcr.io/coreweave/nccl-tests:12.9.1-devel-ubuntu22.04-nccl2.28.3-1-b87f806 | 22.04      | 12.9.1   |
+| ghcr.io/coreweave/nccl-tests:12.8.1-devel-ubuntu22.04-nccl2.28.3-1-b87f806 | 22.04      | 12.8.1   |
+| ghcr.io/coreweave/nccl-tests:12.6.3-devel-ubuntu22.04-nccl2.28.3-1-b87f806 | 22.04      | 12.6.3   |
 
 ## Running NCCL Tests
 


### PR DESCRIPTION
# Updating to `NVIDIA/nccl-tests` v2.17.1, HPC-X v2.24 on CUDA 12

This change updates the following components:
- `NVIDIA/nccl-tests` v2.16.8 → v2.17.1
- HPC-X v2.23 → v2.24
  - This one only applies to CUDA 12 builds, as the CUDA 13 build was already using HPC-X v2.24