### PR TITLE
Set NCCL_NET_PLUGIN=none on all non-SHARP NCCL tests

### DIFF
--- a/mpi-operator/nccl-test-distributed-a100-64-gdrcopy-mpijob.yaml
+++ b/mpi-operator/nccl-test-distributed-a100-64-gdrcopy-mpijob.yaml
@@ -31,6 +31,7 @@ spec:
                   -x NCCL_GDRCOPY_ENABLE=1 \
                   -x NCCL_DEBUG=INFO \
                   -x NCCL_DEBUG_SUBSYS=INIT \
+                  -x NCCL_NET_PLUGIN=none \
                   /opt/nccl_tests/build/all_reduce_perf -b 512M -e 8G -f 2 -g 1
                   ",
                 ]

--- a/mpi-operator/nccl-test-distributed-a100-64-mpijob.yaml
+++ b/mpi-operator/nccl-test-distributed-a100-64-mpijob.yaml
@@ -29,6 +29,7 @@ spec:
                     -x NCCL_SOCKET_IFNAME=eth0 \
                     -x NCCL_IB_HCA=ibp \
                     -x UCX_NET_DEVICES=ibp0:1,ibp1:1,ibp2:1,ibp3:1 \
+                    -x NCCL_NET_PLUGIN=none \
                     /opt/nccl_tests/build/all_reduce_perf -b 512M -e 8G -f 2 -g 1
                     "]
 

--- a/mpi-operator/nccl-test-distributed-a100-64-noib-mpijob.yaml
+++ b/mpi-operator/nccl-test-distributed-a100-64-noib-mpijob.yaml
@@ -30,6 +30,7 @@ spec:
                   -x LD_LIBRARY_PATH \
                   -x NCCL_SOCKET_IFNAME=eth0 \
                   -x NCCL_IB_HCA=eth0 \
+                  -x NCCL_NET_PLUGIN=none \
                   /opt/nccl_tests/build/all_reduce_perf -b 512M -e 8G -f 2 -g 1
                   ",
                 ]

--- a/mpi-operator/nccl-test-distributed-a40-64-mpijob.yaml
+++ b/mpi-operator/nccl-test-distributed-a40-64-mpijob.yaml
@@ -29,6 +29,7 @@ spec:
                     -x NCCL_IB_HCA=ibp \
                     -x NCCL_DEBUG=INFO \
                     -x NCCL_DEBUG_SUBSYS=INIT \
+                    -x NCCL_NET_PLUGIN=none \
                     /opt/nccl_tests/build/all_reduce_perf -b 512M -e 8G -f 2 -g 1
                     "]
 

--- a/mpi-operator/nccl-test-distributed-gb200-128-multirack-mpijob.yaml
+++ b/mpi-operator/nccl-test-distributed-gb200-128-multirack-mpijob.yaml
@@ -42,6 +42,7 @@ spec:
                   -x UCX_TLS=tcp \
                   -x UCX_NET_DEVICES=eth0 \
                   -x OMPI_MCA_coll_hcoll_enable=0 \
+                  -x NCCL_NET_PLUGIN=none \
                   /opt/nccl_tests/build/all_reduce_perf -b 512M -e 8G -f 2 -g 1
                   ",
                 ]

--- a/mpi-operator/nccl-test-distributed-gb200-nvl72-mpijob.yaml
+++ b/mpi-operator/nccl-test-distributed-gb200-nvl72-mpijob.yaml
@@ -39,6 +39,7 @@ spec:
                   -x UCX_TLS=tcp \
                   -x UCX_NET_DEVICES=eth0 \
                   -x OMPI_MCA_coll_hcoll_enable=0 \
+                  -x NCCL_NET_PLUGIN=none \
                   /opt/nccl_tests/build/all_reduce_perf -b 512M -e 8G -f 2 -g 1
                   ",
                 ]

--- a/mpi-operator/nccl-test-distributed-h100-64-mpijob.yaml
+++ b/mpi-operator/nccl-test-distributed-h100-64-mpijob.yaml
@@ -33,6 +33,7 @@ spec:
                   -x UCX_NET_DEVICES=ibp0:1,ibp1:1,ibp2:1,ibp3:1,ibp4:1,ibp5:1,ibp6:1,ibp7:1 \
                   -x SHARP_COLL_ENABLE_PCI_RELAXED_ORDERING=1 \
                   -x NCCL_COLLNET_ENABLE=0 \
+                  -x NCCL_NET_PLUGIN=none \
                   /opt/nccl_tests/build/all_reduce_perf -b 512M -e 8G -f 2 -g 1 #-n 200 #-w 2 -n 20
                   ",
                 ]

--- a/slurm/nccl-test-distributed-a100-64-enroot.slurm
+++ b/slurm/nccl-test-distributed-a100-64-enroot.slurm
@@ -15,6 +15,7 @@
 export NCCL_SOCKET_IFNAME=eth0
 export NCCL_IB_HCA=ibp
 export UCX_NET_DEVICES=ibp0:1,ibp1:1,ibp2:1,ibp3:1
+export NCCL_NET_PLUGIN=none
 
 # Define nccl version we will test
 # See https://github.com/coreweave/nccl-tests/pkgs/container/nccl-tests for available tags.

--- a/slurm/nccl-test-distributed-a100-64.slurm
+++ b/slurm/nccl-test-distributed-a100-64.slurm
@@ -19,6 +19,7 @@ module load image-defaults
 export NCCL_SOCKET_IFNAME=eth0
 export NCCL_IB_HCA=ibp
 export UCX_NET_DEVICES=ibp0:1,ibp1:1,ibp2:1,ibp3:1
+export NCCL_NET_PLUGIN=none
 
 # Log the assigned nodes
 echo "Using nodes: $SLURM_JOB_NODELIST"

--- a/slurm/nccl-test-distributed-gb200-nvl72-enroot.slurm
+++ b/slurm/nccl-test-distributed-gb200-nvl72-enroot.slurm
@@ -37,6 +37,7 @@ export UCX_TLS=tcp
 export UCX_NET_DEVICES=eth0
 export OMPI_MCA_coll_hcoll_enable=0
 export PMIX_MCA_gds='^ds12'
+export NCCL_NET_PLUGIN=none
 
 # Define nccl version we will test
 # See https://github.com/coreweave/nccl-tests/pkgs/container/nccl-tests for available tags.

--- a/slurm/nccl-test-distributed-h100-64-enroot.slurm
+++ b/slurm/nccl-test-distributed-h100-64-enroot.slurm
@@ -26,6 +26,7 @@ export UCX_TLS=tcp
 export UCX_NET_DEVICES=eth0
 export OMPI_MCA_coll_hcoll_enable=0
 export PMIX_MCA_gds='^ds12'
+export NCCL_NET_PLUGIN=none
 
 # Define nccl version we will test
 # See https://github.com/coreweave/nccl-tests/pkgs/container/nccl-tests for available tags.

--- a/slurm/nccl-test-distributed-h100-64.slurm
+++ b/slurm/nccl-test-distributed-h100-64.slurm
@@ -30,6 +30,7 @@ export UCX_TLS=tcp
 export UCX_NET_DEVICES=eth0
 export OMPI_MCA_coll_hcoll_enable=0
 export PMIX_MCA_gds='^ds12'
+export NCCL_NET_PLUGIN=none
 
 # Log the assigned nodes
 echo "Using nodes: $SLURM_JOB_NODELIST"


### PR DESCRIPTION
## Summary
The NCCL SHARP plugin from HPC-X is on path in many of our environments, as part of HPC-X. There is no need to use it for non-SHARP enabled jobs, and there is always some risk that it degrades performance. 

## Files changed
**MPI Operator (added `-x NCCL_NET_PLUGIN=none`):**
- `nccl-test-distributed-a100-64-mpijob.yaml`
- `nccl-test-distributed-a100-64-gdrcopy-mpijob.yaml`
- `nccl-test-distributed-a100-64-noib-mpijob.yaml`
- `nccl-test-distributed-a40-64-mpijob.yaml`
- `nccl-test-distributed-gb200-nvl72-mpijob.yaml`
- `nccl-test-distributed-gb200-128-multirack-mpijob.yaml`
- `nccl-test-distributed-h100-64-mpijob.yaml`

**Slurm (added `export NCCL_NET_PLUGIN=none`):**
- `nccl-test-distributed-a100-64-enroot.slurm`
- `nccl-test-distributed-a100-64.slurm`
- `nccl-test-distributed-gb200-nvl72-enroot.slurm`
- `nccl-test-distributed-h100-64-enroot.slurm`
- `nccl-test-distributed-h100-64.slurm`