### PR TITLE
feat: Update to NCCL 2.30.3-1

### DIFF
--- a/.github/workflows/ubuntu-22.yml
+++ b/.github/workflows/ubuntu-22.yml
@@ -21,7 +21,7 @@ jobs:
       base-image: nvidia/cuda
       base-tag: 12.6.3-devel-ubuntu22.04
       cuda-version: "12.6.3"
-      nccl-version: 2.30.0-1
+      nccl-version: 2.30.3-1
       hpcx-distribution: "hpcx-v2.26-gcc-doca_ofed-ubuntu22.04-cuda12"
 
   cu128:
@@ -38,7 +38,7 @@ jobs:
       base-image: nvidia/cuda
       base-tag: 12.8.1-devel-ubuntu22.04
       cuda-version: "12.8.1"
-      nccl-version: 2.30.0-1
+      nccl-version: 2.30.3-1
       hpcx-distribution: "hpcx-v2.26-gcc-doca_ofed-ubuntu22.04-cuda12"
 
   cu129:
@@ -55,7 +55,7 @@ jobs:
       base-image: nvidia/cuda
       base-tag: 12.9.1-devel-ubuntu22.04
       cuda-version: "12.9.1"
-      nccl-version: 2.30.0-1
+      nccl-version: 2.30.3-1
       hpcx-distribution: "hpcx-v2.26-gcc-doca_ofed-ubuntu22.04-cuda12"
 
   cu130:
@@ -72,7 +72,7 @@ jobs:
       base-image: nvidia/cuda
       base-tag: 13.0.2-devel-ubuntu22.04
       cuda-version: "13.0.2"
-      nccl-version: 2.30.0-1
+      nccl-version: 2.30.3-1
       hpcx-distribution: "hpcx-v2.26-gcc-doca_ofed-ubuntu22.04-cuda13"
 
   cu131:
@@ -89,7 +89,7 @@ jobs:
       base-image: nvidia/cuda
       base-tag: 13.1.1-devel-ubuntu22.04
       cuda-version: "13.1.1"
-      nccl-version: 2.30.0-1
+      nccl-version: 2.30.3-1
       hpcx-distribution: "hpcx-v2.26-gcc-doca_ofed-ubuntu22.04-cuda13"
 
   cu132:
@@ -106,5 +106,5 @@ jobs:
       base-image: nvidia/cuda
       base-tag: 13.2.0-devel-ubuntu22.04
       cuda-version: "13.2.0"
-      nccl-version: 2.30.0-1
+      nccl-version: 2.30.3-1
       hpcx-distribution: "hpcx-v2.26-gcc-doca_ofed-ubuntu22.04-cuda13"

--- a/.github/workflows/ubuntu-22.yml
+++ b/.github/workflows/ubuntu-22.yml
@@ -21,7 +21,7 @@ jobs:
       base-image: nvidia/cuda
       base-tag: 12.6.3-devel-ubuntu22.04
       cuda-version: "12.6.3"
-      nccl-version: 2.29.7-1
+      nccl-version: 2.30.0-1
       hpcx-distribution: "hpcx-v2.26-gcc-doca_ofed-ubuntu22.04-cuda12"
 
   cu128:
@@ -38,7 +38,7 @@ jobs:
       base-image: nvidia/cuda
       base-tag: 12.8.1-devel-ubuntu22.04
       cuda-version: "12.8.1"
-      nccl-version: 2.29.7-1
+      nccl-version: 2.30.0-1
       hpcx-distribution: "hpcx-v2.26-gcc-doca_ofed-ubuntu22.04-cuda12"
 
   cu129:
@@ -55,7 +55,7 @@ jobs:
       base-image: nvidia/cuda
       base-tag: 12.9.1-devel-ubuntu22.04
       cuda-version: "12.9.1"
-      nccl-version: 2.29.7-1
+      nccl-version: 2.30.0-1
       hpcx-distribution: "hpcx-v2.26-gcc-doca_ofed-ubuntu22.04-cuda12"
 
   cu130:
@@ -72,7 +72,7 @@ jobs:
       base-image: nvidia/cuda
       base-tag: 13.0.2-devel-ubuntu22.04
       cuda-version: "13.0.2"
-      nccl-version: 2.29.7-1
+      nccl-version: 2.30.0-1
       hpcx-distribution: "hpcx-v2.26-gcc-doca_ofed-ubuntu22.04-cuda13"
 
   cu131:
@@ -89,7 +89,7 @@ jobs:
       base-image: nvidia/cuda
       base-tag: 13.1.1-devel-ubuntu22.04
       cuda-version: "13.1.1"
-      nccl-version: 2.29.7-1
+      nccl-version: 2.30.0-1
       hpcx-distribution: "hpcx-v2.26-gcc-doca_ofed-ubuntu22.04-cuda13"
 
   cu132:
@@ -106,5 +106,5 @@ jobs:
       base-image: nvidia/cuda
       base-tag: 13.2.0-devel-ubuntu22.04
       cuda-version: "13.2.0"
-      nccl-version: 2.29.7-1
+      nccl-version: 2.30.0-1
       hpcx-distribution: "hpcx-v2.26-gcc-doca_ofed-ubuntu22.04-cuda13"

--- a/.github/workflows/ubuntu-24.yml
+++ b/.github/workflows/ubuntu-24.yml
@@ -21,7 +21,7 @@ jobs:
       base-image: nvidia/cuda
       base-tag: 12.9.1-devel-ubuntu24.04
       cuda-version: "12.9.1"
-      nccl-version: 2.30.0-1
+      nccl-version: 2.30.3-1
       hpcx-distribution: "hpcx-v2.26-gcc-doca_ofed-ubuntu24.04-cuda12"
 
   cu130:
@@ -38,7 +38,7 @@ jobs:
       base-image: nvidia/cuda
       base-tag: 13.0.2-devel-ubuntu24.04
       cuda-version: "13.0.2"
-      nccl-version: 2.30.0-1
+      nccl-version: 2.30.3-1
       hpcx-distribution: "hpcx-v2.26-gcc-doca_ofed-ubuntu24.04-cuda13"
 
   cu131:
@@ -55,7 +55,7 @@ jobs:
       base-image: nvidia/cuda
       base-tag: 13.1.1-devel-ubuntu24.04
       cuda-version: "13.1.1"
-      nccl-version: 2.30.0-1
+      nccl-version: 2.30.3-1
       hpcx-distribution: "hpcx-v2.26-gcc-doca_ofed-ubuntu24.04-cuda13"
 
   cu132:
@@ -72,5 +72,5 @@ jobs:
       base-image: nvidia/cuda
       base-tag: 13.2.0-devel-ubuntu24.04
       cuda-version: "13.2.0"
-      nccl-version: 2.30.0-1
+      nccl-version: 2.30.3-1
       hpcx-distribution: "hpcx-v2.26-gcc-doca_ofed-ubuntu24.04-cuda13"

--- a/.github/workflows/ubuntu-24.yml
+++ b/.github/workflows/ubuntu-24.yml
@@ -21,7 +21,7 @@ jobs:
       base-image: nvidia/cuda
       base-tag: 12.9.1-devel-ubuntu24.04
       cuda-version: "12.9.1"
-      nccl-version: 2.29.7-1
+      nccl-version: 2.30.0-1
       hpcx-distribution: "hpcx-v2.26-gcc-doca_ofed-ubuntu24.04-cuda12"
 
   cu130:
@@ -38,7 +38,7 @@ jobs:
       base-image: nvidia/cuda
       base-tag: 13.0.2-devel-ubuntu24.04
       cuda-version: "13.0.2"
-      nccl-version: 2.29.7-1
+      nccl-version: 2.30.0-1
       hpcx-distribution: "hpcx-v2.26-gcc-doca_ofed-ubuntu24.04-cuda13"
 
   cu131:
@@ -55,7 +55,7 @@ jobs:
       base-image: nvidia/cuda
       base-tag: 13.1.1-devel-ubuntu24.04
       cuda-version: "13.1.1"
-      nccl-version: 2.29.7-1
+      nccl-version: 2.30.0-1
       hpcx-distribution: "hpcx-v2.26-gcc-doca_ofed-ubuntu24.04-cuda13"
 
   cu132:
@@ -72,5 +72,5 @@ jobs:
       base-image: nvidia/cuda
       base-tag: 13.2.0-devel-ubuntu24.04
       cuda-version: "13.2.0"
-      nccl-version: 2.29.7-1
+      nccl-version: 2.30.0-1
       hpcx-distribution: "hpcx-v2.26-gcc-doca_ofed-ubuntu24.04-cuda13"

--- a/Dockerfile
+++ b/Dockerfile
@@ -63,7 +63,7 @@ RUN apt-get -qq update && \
 
 FROM builder-base AS libnccl2
 # NCCL
-ARG TARGET_NCCL_VERSION='2.29.7-1'
+ARG TARGET_NCCL_VERSION='2.30.0-1'
 ARG CUDA_ARCH_LIST='80 89 90 100 120'
 # Converts CUDA_ARCH_LIST to '-gencode=arch=compute_XX,code=sm_XX -gencode=...' format with PTX for the last listed arch
 RUN case "${CUDA_VERSION}" in 12.[0-7].*) \

--- a/Dockerfile
+++ b/Dockerfile
@@ -63,7 +63,7 @@ RUN apt-get -qq update && \
 
 FROM builder-base AS libnccl2
 # NCCL
-ARG TARGET_NCCL_VERSION='2.30.0-1'
+ARG TARGET_NCCL_VERSION='2.30.3-1'
 ARG CUDA_ARCH_LIST='80 89 90 100 120'
 # Converts CUDA_ARCH_LIST to '-gencode=arch=compute_XX,code=sm_XX -gencode=...' format with PTX for the last listed arch
 RUN case "${CUDA_VERSION}" in 12.[0-7].*) \

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ the following components:
 CoreWeave
 also [publishes images](https://github.com/coreweave/nccl-tests/pkgs/container/nccl-tests)
 built from these Dockerfiles that can be used as base for your own images.  
-The images below include **NCCL v2.29.7-1**, **HPC-X v2.26**,
+The images below include **NCCL v2.30.3-1**, **HPC-X v2.26**,
 and **cuDNN v9.20.0.48-1**.  
 Each image is multi-arch, and can be used for both `linux/amd64` and `linux/arm64` containers.
 Compute capabilities up to Blackwell (10.0 & 12.0) are supported.
@@ -73,21 +73,21 @@ Compute capabilities up to Blackwell (10.0 & 12.0) are supported.
 
 | **Image Tag**                                                              | **CUDA** |
 |----------------------------------------------------------------------------|----------|
-| ghcr.io/coreweave/nccl-tests:13.2.0-devel-ubuntu24.04-nccl2.29.7-1-7112046 | 13.2.0   |
-| ghcr.io/coreweave/nccl-tests:13.1.1-devel-ubuntu24.04-nccl2.29.7-1-7112046 | 13.1.1   |
-| ghcr.io/coreweave/nccl-tests:13.0.2-devel-ubuntu24.04-nccl2.29.7-1-7112046 | 13.0.2   |
-| ghcr.io/coreweave/nccl-tests:12.9.1-devel-ubuntu24.04-nccl2.29.7-1-7112046 | 12.9.1   |
+| ghcr.io/coreweave/nccl-tests:13.2.0-devel-ubuntu24.04-nccl2.30.3-1-49210fb | 13.2.0   |
+| ghcr.io/coreweave/nccl-tests:13.1.1-devel-ubuntu24.04-nccl2.30.3-1-49210fb | 13.1.1   |
+| ghcr.io/coreweave/nccl-tests:13.0.2-devel-ubuntu24.04-nccl2.30.3-1-49210fb | 13.0.2   |
+| ghcr.io/coreweave/nccl-tests:12.9.1-devel-ubuntu24.04-nccl2.30.3-1-49210fb | 12.9.1   |
 
 ### Ubuntu 22.04
 
 | **Image Tag**                                                              | **CUDA** |
 |----------------------------------------------------------------------------|----------|
-| ghcr.io/coreweave/nccl-tests:13.2.0-devel-ubuntu22.04-nccl2.29.7-1-7112046 | 13.2.0   |
-| ghcr.io/coreweave/nccl-tests:13.1.1-devel-ubuntu22.04-nccl2.29.7-1-7112046 | 13.1.1   |
-| ghcr.io/coreweave/nccl-tests:13.0.2-devel-ubuntu22.04-nccl2.29.7-1-7112046 | 13.0.2   |
-| ghcr.io/coreweave/nccl-tests:12.9.1-devel-ubuntu22.04-nccl2.29.7-1-7112046 | 12.9.1   |
-| ghcr.io/coreweave/nccl-tests:12.8.1-devel-ubuntu22.04-nccl2.29.7-1-7112046 | 12.8.1   |
-| ghcr.io/coreweave/nccl-tests:12.6.3-devel-ubuntu22.04-nccl2.29.7-1-7112046 | 12.6.3   |
+| ghcr.io/coreweave/nccl-tests:13.2.0-devel-ubuntu22.04-nccl2.30.3-1-49210fb | 13.2.0   |
+| ghcr.io/coreweave/nccl-tests:13.1.1-devel-ubuntu22.04-nccl2.30.3-1-49210fb | 13.1.1   |
+| ghcr.io/coreweave/nccl-tests:13.0.2-devel-ubuntu22.04-nccl2.30.3-1-49210fb | 13.0.2   |
+| ghcr.io/coreweave/nccl-tests:12.9.1-devel-ubuntu22.04-nccl2.30.3-1-49210fb | 12.9.1   |
+| ghcr.io/coreweave/nccl-tests:12.8.1-devel-ubuntu22.04-nccl2.30.3-1-49210fb | 12.8.1   |
+| ghcr.io/coreweave/nccl-tests:12.6.3-devel-ubuntu22.04-nccl2.30.3-1-49210fb | 12.6.3   |
 
 ## Running NCCL Tests
 


### PR DESCRIPTION
# NCCL 2.30.3-1

This change updates NCCL from [2.29.7-1](https://github.com/NVIDIA/nccl/releases/tag/v2.29.7-1) to [2.30.3-1](https://github.com/NVIDIA/nccl/releases/tag/v2.30.3-1).

There were some builds of NCCL 2.30.0-1 at commit NVIDIA/nccl@1e8695afce1205868baa33a69c91263bdabb239f inbetween these in this repo at commit 9fdf08b39e23455d370a7c90a0c86d013706fc39, but 2.30.0-1 never got a tagged release. The [diff between 2.30.0-1 and 2.30.3-1 can be viewed here](https://github.com/NVIDIA/nccl/compare/1e8695afce1205868baa33a69c91263bdabb239f...v2.30.3-1).