### PR TITLE
feat: Update `NVIDIA/nccl-tests` version to 2.18.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -276,7 +276,7 @@ ENV UCX_VFS_ENABLE=no
 #     rm -r /tmp/*
 
 # NCCL Tests
-ENV NCCL_TESTS_COMMITISH=9a5c15461abcef145b907c54d04aea4e8d1cb21f
+ENV NCCL_TESTS_COMMITISH=f727aa2a540fef911de9d7bfd8852bc5d2c69815
 WORKDIR /opt/nccl-tests
 RUN wget -q -O - https://github.com/NVIDIA/nccl-tests/archive/${NCCL_TESTS_COMMITISH}.tar.gz | tar --strip-components=1 -xzf - && \
     make -j20 MPI=1 && \

--- a/README.md
+++ b/README.md
@@ -73,21 +73,21 @@ Compute capabilities up to Blackwell (10.0 & 12.0) are supported.
 
 | **Image Tag**                                                              | **CUDA** |
 |----------------------------------------------------------------------------|----------|
-| ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.30.4-1-111c25a | 13.2.1   |
-| ghcr.io/coreweave/nccl-tests:13.1.1-devel-ubuntu24.04-nccl2.30.4-1-111c25a | 13.1.1   |
-| ghcr.io/coreweave/nccl-tests:13.0.2-devel-ubuntu24.04-nccl2.30.4-1-111c25a | 13.0.2   |
-| ghcr.io/coreweave/nccl-tests:12.9.1-devel-ubuntu24.04-nccl2.30.4-1-111c25a | 12.9.1   |
+| ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.30.4-1-2eedd7c | 13.2.1   |
+| ghcr.io/coreweave/nccl-tests:13.1.1-devel-ubuntu24.04-nccl2.30.4-1-2eedd7c | 13.1.1   |
+| ghcr.io/coreweave/nccl-tests:13.0.2-devel-ubuntu24.04-nccl2.30.4-1-2eedd7c | 13.0.2   |
+| ghcr.io/coreweave/nccl-tests:12.9.1-devel-ubuntu24.04-nccl2.30.4-1-2eedd7c | 12.9.1   |
 
 ### Ubuntu 22.04
 
 | **Image Tag**                                                              | **CUDA** |
 |----------------------------------------------------------------------------|----------|
-| ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu22.04-nccl2.30.4-1-111c25a | 13.2.1   |
-| ghcr.io/coreweave/nccl-tests:13.1.1-devel-ubuntu22.04-nccl2.30.4-1-111c25a | 13.1.1   |
-| ghcr.io/coreweave/nccl-tests:13.0.2-devel-ubuntu22.04-nccl2.30.4-1-111c25a | 13.0.2   |
-| ghcr.io/coreweave/nccl-tests:12.9.1-devel-ubuntu22.04-nccl2.30.4-1-111c25a | 12.9.1   |
-| ghcr.io/coreweave/nccl-tests:12.8.1-devel-ubuntu22.04-nccl2.30.4-1-111c25a | 12.8.1   |
-| ghcr.io/coreweave/nccl-tests:12.6.3-devel-ubuntu22.04-nccl2.30.4-1-111c25a | 12.6.3   |
+| ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu22.04-nccl2.30.4-1-2eedd7c | 13.2.1   |
+| ghcr.io/coreweave/nccl-tests:13.1.1-devel-ubuntu22.04-nccl2.30.4-1-2eedd7c | 13.1.1   |
+| ghcr.io/coreweave/nccl-tests:13.0.2-devel-ubuntu22.04-nccl2.30.4-1-2eedd7c | 13.0.2   |
+| ghcr.io/coreweave/nccl-tests:12.9.1-devel-ubuntu22.04-nccl2.30.4-1-2eedd7c | 12.9.1   |
+| ghcr.io/coreweave/nccl-tests:12.8.1-devel-ubuntu22.04-nccl2.30.4-1-2eedd7c | 12.8.1   |
+| ghcr.io/coreweave/nccl-tests:12.6.3-devel-ubuntu22.04-nccl2.30.4-1-2eedd7c | 12.6.3   |
 
 ## Running NCCL Tests
 


### PR DESCRIPTION
# Updating to `NVIDIA/nccl-tests` v2.18.3

This change updates `NVIDIA/nccl-tests` from [v2.17.1](https://github.com/NVIDIA/nccl-tests/releases/tag/v2.17.1) → [v2.18.3](https://github.com/NVIDIA/nccl-tests/releases/tag/v2.18.3).

This adds the following notable flags to NCCL test binaries:
- `-J` / `--output_file`
- `-T` / `--timeout`
- `-S` / `--report_timestamps`
- `-M` / `--memory_report`
- `-u` / `--unalign`