### PR TITLE
feat: bump NCCL test images to cuda 13.2.1 / nccl 2.30.4

### DIFF
--- a/mpi-operator/nccl-test-distributed-a100-64-gdrcopy-mpijob.yaml
+++ b/mpi-operator/nccl-test-distributed-a100-64-gdrcopy-mpijob.yaml
@@ -12,7 +12,7 @@ spec:
       template:
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:12.9.1-devel-ubuntu22.04-nccl2.28.3-1-8b67957
+            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu22.04-nccl2.30.4-1-2eedd7c
               name: nccl
               env:
                 - name: OMPI_ALLOW_RUN_AS_ROOT
@@ -44,7 +44,7 @@ spec:
       template:
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:12.9.1-devel-ubuntu22.04-nccl2.28.3-1-8b67957
+            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu22.04-nccl2.30.4-1-2eedd7c
               name: nccl
               resources:
                 requests:

--- a/mpi-operator/nccl-test-distributed-a100-64-mpijob.yaml
+++ b/mpi-operator/nccl-test-distributed-a100-64-mpijob.yaml
@@ -12,7 +12,7 @@ spec:
       template:
           spec:
             containers:
-            - image: ghcr.io/coreweave/nccl-tests:12.9.1-devel-ubuntu22.04-nccl2.28.3-1-8b67957
+            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu22.04-nccl2.30.4-1-2eedd7c
               name: nccl
               env:
               - name: OMPI_ALLOW_RUN_AS_ROOT
@@ -45,7 +45,7 @@ spec:
             metadata.coreweave.cloud/job: nccl-test
         spec:
           containers:
-          - image: ghcr.io/coreweave/nccl-tests:12.9.1-devel-ubuntu22.04-nccl2.28.3-1-8b67957
+          - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu22.04-nccl2.30.4-1-2eedd7c
             name: nccl
             resources:
               requests:

--- a/mpi-operator/nccl-test-distributed-a100-64-noib-mpijob.yaml
+++ b/mpi-operator/nccl-test-distributed-a100-64-noib-mpijob.yaml
@@ -12,7 +12,7 @@ spec:
       template:
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:12.9.1-devel-ubuntu22.04-nccl2.28.3-1-8b67957
+            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu22.04-nccl2.30.4-1-2eedd7c
               name: nccl
               env:
                 - name: OMPI_ALLOW_RUN_AS_ROOT
@@ -47,7 +47,7 @@ spec:
             metadata.coreweave.cloud/job: nccl-test
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:12.9.1-devel-ubuntu22.04-nccl2.28.3-1-8b67957
+            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu22.04-nccl2.30.4-1-2eedd7c
               name: nccl
               resources:
                 requests:

--- a/mpi-operator/nccl-test-distributed-a100-64-sharp-mpijob.yaml
+++ b/mpi-operator/nccl-test-distributed-a100-64-sharp-mpijob.yaml
@@ -12,7 +12,7 @@ spec:
       template:
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:12.9.1-devel-ubuntu22.04-nccl2.28.3-1-8b67957
+            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu22.04-nccl2.30.4-1-2eedd7c
               name: nccl
               env:
                 - name: OMPI_ALLOW_RUN_AS_ROOT
@@ -48,7 +48,7 @@ spec:
             metadata.coreweave.cloud/job: nccl-test
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:12.9.1-devel-ubuntu22.04-nccl2.28.3-1-8b67957
+            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu22.04-nccl2.30.4-1-2eedd7c
               name: nccl
               resources:
                 requests:

--- a/mpi-operator/nccl-test-distributed-b200-64-mpijob.yaml
+++ b/mpi-operator/nccl-test-distributed-b200-64-mpijob.yaml
@@ -12,7 +12,7 @@ spec:
       template:
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:12.9.1-devel-ubuntu22.04-nccl2.28.3-1-8b67957
+            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu22.04-nccl2.30.4-1-2eedd7c
               name: nccl
               env:
                 - name: OMPI_ALLOW_RUN_AS_ROOT
@@ -49,7 +49,7 @@ spec:
             metadata.coreweave.cloud/job: nccl-test
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:12.9.1-devel-ubuntu22.04-nccl2.28.3-1-8b67957
+            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu22.04-nccl2.30.4-1-2eedd7c
               name: nccl
               resources:
                 requests:

--- a/mpi-operator/nccl-test-distributed-b200-64-sharp-mpijob.yaml
+++ b/mpi-operator/nccl-test-distributed-b200-64-sharp-mpijob.yaml
@@ -12,7 +12,7 @@ spec:
       template:
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:12.9.1-devel-ubuntu22.04-nccl2.28.3-1-8b67957
+            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu22.04-nccl2.30.4-1-2eedd7c
               name: nccl
               env:
                 - name: OMPI_ALLOW_RUN_AS_ROOT
@@ -49,7 +49,7 @@ spec:
             metadata.coreweave.cloud/job: nccl-test
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:12.9.1-devel-ubuntu22.04-nccl2.28.3-1-8b67957
+            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu22.04-nccl2.30.4-1-2eedd7c
               name: nccl
               resources:
                 requests:

--- a/mpi-operator/nccl-test-distributed-b300-64-mpijob.yaml
+++ b/mpi-operator/nccl-test-distributed-b300-64-mpijob.yaml
@@ -12,7 +12,7 @@ spec:
       template:
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:12.9.1-devel-ubuntu22.04-nccl2.28.3-1-8b67957
+            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu22.04-nccl2.30.4-1-2eedd7c
               name: nccl
               env:
                 - name: OMPI_ALLOW_RUN_AS_ROOT
@@ -49,7 +49,7 @@ spec:
             metadata.coreweave.cloud/job: nccl-test
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:12.9.1-devel-ubuntu22.04-nccl2.28.3-1-8b67957
+            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu22.04-nccl2.30.4-1-2eedd7c
               name: nccl
               resources:
                 requests:

--- a/mpi-operator/nccl-test-distributed-b300-64-sharp-mpijob.yaml
+++ b/mpi-operator/nccl-test-distributed-b300-64-sharp-mpijob.yaml
@@ -12,7 +12,7 @@ spec:
       template:
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:12.9.1-devel-ubuntu22.04-nccl2.28.3-1-8b67957
+            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu22.04-nccl2.30.4-1-2eedd7c
               name: nccl
               env:
                 - name: OMPI_ALLOW_RUN_AS_ROOT
@@ -49,7 +49,7 @@ spec:
             metadata.coreweave.cloud/job: nccl-test
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:12.9.1-devel-ubuntu22.04-nccl2.28.3-1-8b67957
+            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu22.04-nccl2.30.4-1-2eedd7c
               name: nccl
               resources:
                 requests:

--- a/mpi-operator/nccl-test-distributed-gb200-128-multirack-mpijob.yaml
+++ b/mpi-operator/nccl-test-distributed-gb200-128-multirack-mpijob.yaml
@@ -17,7 +17,7 @@ spec:
       template:
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:12.9.1-devel-ubuntu22.04-nccl2.28.3-1-8b67957
+            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu22.04-nccl2.30.4-1-2eedd7c
               name: nccl
               env:
                 - name: OMPI_ALLOW_RUN_AS_ROOT
@@ -70,7 +70,7 @@ spec:
                 matchLabels:
                   metadata.coreweave.cloud/job: nccl-test
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:12.9.1-devel-ubuntu22.04-nccl2.28.3-1-8b67957
+            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu22.04-nccl2.30.4-1-2eedd7c
               name: nccl
               resources:
                 requests:

--- a/mpi-operator/nccl-test-distributed-gb200-nvl72-mpijob.yaml
+++ b/mpi-operator/nccl-test-distributed-gb200-nvl72-mpijob.yaml
@@ -14,7 +14,7 @@ spec:
       template:
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:12.9.1-devel-ubuntu22.04-nccl2.28.3-1-8b67957
+            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu22.04-nccl2.30.4-1-2eedd7c
               name: nccl
               env:
                 - name: OMPI_ALLOW_RUN_AS_ROOT
@@ -55,7 +55,7 @@ spec:
             metadata.coreweave.cloud/job: nccl-test
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:12.9.1-devel-ubuntu22.04-nccl2.28.3-1-8b67957
+            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu22.04-nccl2.30.4-1-2eedd7c
               name: nccl
               resources:
                 requests:

--- a/mpi-operator/nccl-test-distributed-gb300-nvl72-mpijob.yaml
+++ b/mpi-operator/nccl-test-distributed-gb300-nvl72-mpijob.yaml
@@ -16,7 +16,7 @@ spec:
       template:
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:12.9.1-devel-ubuntu22.04-nccl2.28.3-1-8b67957
+            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu22.04-nccl2.30.4-1-2eedd7c
               name: nccl
               env:
                 - name: OMPI_ALLOW_RUN_AS_ROOT
@@ -57,7 +57,7 @@ spec:
             metadata.coreweave.cloud/job: nccl-test
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:12.9.1-devel-ubuntu22.04-nccl2.28.3-1-8b67957
+            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu22.04-nccl2.30.4-1-2eedd7c
               name: nccl
               resources:
                 requests:

--- a/mpi-operator/nccl-test-distributed-gb300-roce-128-multirack-mpijob-dra.yaml
+++ b/mpi-operator/nccl-test-distributed-gb300-roce-128-multirack-mpijob-dra.yaml
@@ -35,7 +35,7 @@ spec:
       template:
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:13.1.0-devel-ubuntu22.04-nccl2.29.2-1-0bf62c2
+            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu22.04-nccl2.30.4-1-2eedd7c
               name: nccl
               env:
                 - name: OMPI_ALLOW_RUN_AS_ROOT
@@ -145,7 +145,7 @@ spec:
                 matchLabels:
                   metadata.coreweave.cloud/job: nccl-test
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:13.1.0-devel-ubuntu22.04-nccl2.29.2-1-0bf62c2
+            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu22.04-nccl2.30.4-1-2eedd7c
               name: nccl
               resources:
                 requests:

--- a/mpi-operator/nccl-test-distributed-gb300-roce-128-multirack-mpijob.yaml
+++ b/mpi-operator/nccl-test-distributed-gb300-roce-128-multirack-mpijob.yaml
@@ -18,7 +18,7 @@ spec:
       template:
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:13.1.0-devel-ubuntu22.04-nccl2.29.2-1-0bf62c2
+            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu22.04-nccl2.30.4-1-2eedd7c
               name: nccl
               env:
                 - name: OMPI_ALLOW_RUN_AS_ROOT
@@ -128,7 +128,7 @@ spec:
                 matchLabels:
                   metadata.coreweave.cloud/job: nccl-test
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:13.1.0-devel-ubuntu22.04-nccl2.29.2-1-0bf62c2
+            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu22.04-nccl2.30.4-1-2eedd7c
               name: nccl
               resources:
                 requests:

--- a/mpi-operator/nccl-test-distributed-gb300-roce-nvl72-mpijob-dra.yaml
+++ b/mpi-operator/nccl-test-distributed-gb300-roce-nvl72-mpijob-dra.yaml
@@ -32,7 +32,7 @@ spec:
       template:
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:13.1.0-devel-ubuntu22.04-nccl2.29.2-1-0bf62c2
+            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu22.04-nccl2.30.4-1-2eedd7c
               name: nccl
               env:
                 - name: OMPI_ALLOW_RUN_AS_ROOT
@@ -130,7 +130,7 @@ spec:
               }]
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:13.1.0-devel-ubuntu22.04-nccl2.29.2-1-0bf62c2
+            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu22.04-nccl2.30.4-1-2eedd7c
               name: nccl
               resources:
                 requests:

--- a/mpi-operator/nccl-test-distributed-gb300-roce-nvl72-mpijob.yaml
+++ b/mpi-operator/nccl-test-distributed-gb300-roce-nvl72-mpijob.yaml
@@ -15,7 +15,7 @@ spec:
       template:
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:13.1.0-devel-ubuntu22.04-nccl2.29.2-1-0bf62c2
+            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu22.04-nccl2.30.4-1-2eedd7c
               name: nccl
               env:
                 - name: OMPI_ALLOW_RUN_AS_ROOT
@@ -113,7 +113,7 @@ spec:
               }]
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:13.1.0-devel-ubuntu22.04-nccl2.29.2-1-0bf62c2
+            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu22.04-nccl2.30.4-1-2eedd7c
               name: nccl
               resources:
                 requests:

--- a/mpi-operator/nccl-test-distributed-h100-64-mpijob.yaml
+++ b/mpi-operator/nccl-test-distributed-h100-64-mpijob.yaml
@@ -12,7 +12,7 @@ spec:
       template:
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:12.9.1-devel-ubuntu22.04-nccl2.28.3-1-8b67957
+            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu22.04-nccl2.30.4-1-2eedd7c
               name: nccl
               env:
                 - name: OMPI_ALLOW_RUN_AS_ROOT
@@ -49,7 +49,7 @@ spec:
             metadata.coreweave.cloud/job: nccl-test
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:12.9.1-devel-ubuntu22.04-nccl2.28.3-1-8b67957
+            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu22.04-nccl2.30.4-1-2eedd7c
               name: nccl
               resources:
                 requests:

--- a/mpi-operator/nccl-test-distributed-h100-64-sharp-mpijob.yaml
+++ b/mpi-operator/nccl-test-distributed-h100-64-sharp-mpijob.yaml
@@ -12,7 +12,7 @@ spec:
       template:
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:12.9.1-devel-ubuntu22.04-nccl2.28.3-1-8b67957
+            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu22.04-nccl2.30.4-1-2eedd7c
               name: nccl
               env:
                 - name: OMPI_ALLOW_RUN_AS_ROOT
@@ -49,7 +49,7 @@ spec:
             metadata.coreweave.cloud/job: nccl-test
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:12.9.1-devel-ubuntu22.04-nccl2.28.3-1-8b67957
+            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu22.04-nccl2.30.4-1-2eedd7c
               name: nccl
               resources:
                 requests:

--- a/slurm/nccl-test-distributed-a100-64-enroot.slurm
+++ b/slurm/nccl-test-distributed-a100-64-enroot.slurm
@@ -20,7 +20,7 @@ export NCCL_NET_PLUGIN=none
 # Define nccl version we will test
 # See https://github.com/coreweave/nccl-tests/pkgs/container/nccl-tests for available tags.
 
-nccl_version="12.9.1-devel-ubuntu22.04-nccl2.28.3-1-8b67957"
+nccl_version="13.2.1-devel-ubuntu22.04-nccl2.30.4-1-2eedd7c"
 
 # Create a directory to store container images. You can change this
 # or use an existing directory below.

--- a/slurm/nccl-test-distributed-b200-64-enroot-sharp.slurm
+++ b/slurm/nccl-test-distributed-b200-64-enroot-sharp.slurm
@@ -34,7 +34,7 @@ export PMIX_MCA_gds='^ds12'
 # Define nccl version we will test
 # See https://github.com/coreweave/nccl-tests/pkgs/container/nccl-tests for available tags.
 
-nccl_version="12.9.1-devel-ubuntu22.04-nccl2.28.3-1-8b67957"
+nccl_version="13.2.1-devel-ubuntu22.04-nccl2.30.4-1-2eedd7c"
 
 # Create a directory to store container images. You can change this
 # or use an existing directory below.

--- a/slurm/nccl-test-distributed-b200-64-enroot.slurm
+++ b/slurm/nccl-test-distributed-b200-64-enroot.slurm
@@ -31,7 +31,7 @@ export NCCL_NET_PLUGIN=none
 # Define nccl version we will test
 # See https://github.com/coreweave/nccl-tests/pkgs/container/nccl-tests for available tags.
 
-nccl_version="12.9.1-devel-ubuntu22.04-nccl2.28.3-1-8b67957"
+nccl_version="13.2.1-devel-ubuntu22.04-nccl2.30.4-1-2eedd7c"
 
 # Create a directory to store container images. You can change this
 # or use an existing directory below.

--- a/slurm/nccl-test-distributed-b300-64-enroot-sharp.slurm
+++ b/slurm/nccl-test-distributed-b300-64-enroot-sharp.slurm
@@ -34,7 +34,7 @@ export PMIX_MCA_gds='^ds12'
 # Define nccl version we will test
 # See https://github.com/coreweave/nccl-tests/pkgs/container/nccl-tests for available tags.
 
-nccl_version="12.9.1-devel-ubuntu22.04-nccl2.28.3-1-8b67957"
+nccl_version="13.2.1-devel-ubuntu22.04-nccl2.30.4-1-2eedd7c"
 
 # Create a directory to store container images. You can change this
 # or use an existing directory below.

--- a/slurm/nccl-test-distributed-b300-64-enroot.slurm
+++ b/slurm/nccl-test-distributed-b300-64-enroot.slurm
@@ -31,7 +31,7 @@ export NCCL_NET_PLUGIN=none
 # Define nccl version we will test
 # See https://github.com/coreweave/nccl-tests/pkgs/container/nccl-tests for available tags.
 
-nccl_version="12.9.1-devel-ubuntu22.04-nccl2.28.3-1-8b67957"
+nccl_version="13.2.1-devel-ubuntu22.04-nccl2.30.4-1-2eedd7c"
 
 # Create a directory to store container images. You can change this
 # or use an existing directory below.

--- a/slurm/nccl-test-distributed-gb200-nvl72-enroot.slurm
+++ b/slurm/nccl-test-distributed-gb200-nvl72-enroot.slurm
@@ -42,7 +42,7 @@ export NCCL_NET_PLUGIN=none
 # Define nccl version we will test
 # See https://github.com/coreweave/nccl-tests/pkgs/container/nccl-tests for available tags.
 
-nccl_version="12.9.1-devel-ubuntu22.04-nccl2.28.3-1-8b67957"
+nccl_version="13.2.1-devel-ubuntu22.04-nccl2.30.4-1-2eedd7c"
 
 # Create a directory to store container images. You can change this
 # or use an existing directory below.

--- a/slurm/nccl-test-distributed-gb300-nvl72-enroot.slurm
+++ b/slurm/nccl-test-distributed-gb300-nvl72-enroot.slurm
@@ -44,7 +44,7 @@ export NCCL_NET_PLUGIN=none
 # Define nccl version we will test
 # See https://github.com/coreweave/nccl-tests/pkgs/container/nccl-tests for available tags.
 
-nccl_version="12.9.1-devel-ubuntu22.04-nccl2.28.3-1-8b67957"
+nccl_version="13.2.1-devel-ubuntu22.04-nccl2.30.4-1-2eedd7c"
 
 # Create a directory to store container images. You can change this
 # or use an existing directory below.

--- a/slurm/nccl-test-distributed-gb300-roce-nvl72-enroot.slurm
+++ b/slurm/nccl-test-distributed-gb300-roce-nvl72-enroot.slurm
@@ -50,7 +50,7 @@ export PMIX_MCA_gds='^ds12'
 # Define nccl version we will test
 # See https://github.com/coreweave/nccl-tests/pkgs/container/nccl-tests for available tags.
 
-nccl_version="13.1.0-devel-ubuntu22.04-nccl2.29.2-1-0bf62c2"
+nccl_version="13.2.1-devel-ubuntu22.04-nccl2.30.4-1-2eedd7c"
 
 # Create a directory to store container images. You can change this
 # or use an existing directory below.

--- a/slurm/nccl-test-distributed-h100-64-enroot-sharp.slurm
+++ b/slurm/nccl-test-distributed-h100-64-enroot-sharp.slurm
@@ -34,7 +34,7 @@ export PMIX_MCA_gds='^ds12'
 # Define nccl version we will test
 # See https://github.com/coreweave/nccl-tests/pkgs/container/nccl-tests for available tags.
 
-nccl_version="12.9.1-devel-ubuntu22.04-nccl2.28.3-1-8b67957"
+nccl_version="13.2.1-devel-ubuntu22.04-nccl2.30.4-1-2eedd7c"
 
 # Create a directory to store container images. You can change this
 # or use an existing directory below.

--- a/slurm/nccl-test-distributed-h100-64-enroot.slurm
+++ b/slurm/nccl-test-distributed-h100-64-enroot.slurm
@@ -31,7 +31,7 @@ export NCCL_NET_PLUGIN=none
 # Define nccl version we will test
 # See https://github.com/coreweave/nccl-tests/pkgs/container/nccl-tests for available tags.
 
-nccl_version="12.9.1-devel-ubuntu22.04-nccl2.28.3-1-8b67957"
+nccl_version="13.2.1-devel-ubuntu22.04-nccl2.30.4-1-2eedd7c"
 
 # Create a directory to store container images. You can change this
 # or use an existing directory below.


### PR DESCRIPTION
Update all slurm enroot scripts and mpi-operator jobs to 13.2.1-devel-ubuntu22.04-nccl2.30.4-1-2eedd7c.