### PR TITLE
feat: Update to NCCL 2.30.7-1, HPC-X 2.50, & CUDA 13.3.0

### DIFF
--- a/.github/workflows/ubuntu-22.yml
+++ b/.github/workflows/ubuntu-22.yml
@@ -70,8 +70,8 @@ jobs:
       folder: .
       dockerfile: Dockerfile
       base-image: nvidia/cuda
-      base-tag: 13.0.2-devel-ubuntu22.04
-      cuda-version: "13.0.2"
+      base-tag: 13.0.3-devel-ubuntu22.04
+      cuda-version: "13.0.3"
       nccl-version: 2.30.7-1
       hpcx-distribution: "hpcx-v2.50-gcc-doca_ofed-ubuntu22.04-cuda13"
 
@@ -87,8 +87,8 @@ jobs:
       folder: .
       dockerfile: Dockerfile
       base-image: nvidia/cuda
-      base-tag: 13.1.1-devel-ubuntu22.04
-      cuda-version: "13.1.1"
+      base-tag: 13.1.2-devel-ubuntu22.04
+      cuda-version: "13.1.2"
       nccl-version: 2.30.7-1
       hpcx-distribution: "hpcx-v2.50-gcc-doca_ofed-ubuntu22.04-cuda13"
 

--- a/.github/workflows/ubuntu-22.yml
+++ b/.github/workflows/ubuntu-22.yml
@@ -21,8 +21,8 @@ jobs:
       base-image: nvidia/cuda
       base-tag: 12.6.3-devel-ubuntu22.04
       cuda-version: "12.6.3"
-      nccl-version: 2.30.4-1
-      hpcx-distribution: "hpcx-v2.26-gcc-doca_ofed-ubuntu22.04-cuda12"
+      nccl-version: 2.30.7-1
+      hpcx-distribution: "hpcx-v2.50-gcc-doca_ofed-ubuntu22.04-cuda12"
 
   cu128:
     uses: ./.github/workflows/build.yml
@@ -38,8 +38,8 @@ jobs:
       base-image: nvidia/cuda
       base-tag: 12.8.1-devel-ubuntu22.04
       cuda-version: "12.8.1"
-      nccl-version: 2.30.4-1
-      hpcx-distribution: "hpcx-v2.26-gcc-doca_ofed-ubuntu22.04-cuda12"
+      nccl-version: 2.30.7-1
+      hpcx-distribution: "hpcx-v2.50-gcc-doca_ofed-ubuntu22.04-cuda12"
 
   cu129:
     uses: ./.github/workflows/build.yml
@@ -55,8 +55,8 @@ jobs:
       base-image: nvidia/cuda
       base-tag: 12.9.1-devel-ubuntu22.04
       cuda-version: "12.9.1"
-      nccl-version: 2.30.4-1
-      hpcx-distribution: "hpcx-v2.26-gcc-doca_ofed-ubuntu22.04-cuda12"
+      nccl-version: 2.30.7-1
+      hpcx-distribution: "hpcx-v2.50-gcc-doca_ofed-ubuntu22.04-cuda12"
 
   cu130:
     uses: ./.github/workflows/build.yml
@@ -72,8 +72,8 @@ jobs:
       base-image: nvidia/cuda
       base-tag: 13.0.2-devel-ubuntu22.04
       cuda-version: "13.0.2"
-      nccl-version: 2.30.4-1
-      hpcx-distribution: "hpcx-v2.26-gcc-doca_ofed-ubuntu22.04-cuda13"
+      nccl-version: 2.30.7-1
+      hpcx-distribution: "hpcx-v2.50-gcc-doca_ofed-ubuntu22.04-cuda13"
 
   cu131:
     uses: ./.github/workflows/build.yml
@@ -89,8 +89,8 @@ jobs:
       base-image: nvidia/cuda
       base-tag: 13.1.1-devel-ubuntu22.04
       cuda-version: "13.1.1"
-      nccl-version: 2.30.4-1
-      hpcx-distribution: "hpcx-v2.26-gcc-doca_ofed-ubuntu22.04-cuda13"
+      nccl-version: 2.30.7-1
+      hpcx-distribution: "hpcx-v2.50-gcc-doca_ofed-ubuntu22.04-cuda13"
 
   cu132:
     uses: ./.github/workflows/build.yml
@@ -106,5 +106,5 @@ jobs:
       base-image: nvidia/cuda
       base-tag: 13.2.1-devel-ubuntu22.04
       cuda-version: "13.2.1"
-      nccl-version: 2.30.4-1
-      hpcx-distribution: "hpcx-v2.26-gcc-doca_ofed-ubuntu22.04-cuda13"
+      nccl-version: 2.30.7-1
+      hpcx-distribution: "hpcx-v2.50-gcc-doca_ofed-ubuntu22.04-cuda13"

--- a/.github/workflows/ubuntu-22.yml
+++ b/.github/workflows/ubuntu-22.yml
@@ -36,8 +36,8 @@ jobs:
       folder: .
       dockerfile: Dockerfile
       base-image: nvidia/cuda
-      base-tag: 12.8.1-devel-ubuntu22.04
-      cuda-version: "12.8.1"
+      base-tag: 12.8.2-devel-ubuntu22.04
+      cuda-version: "12.8.2"
       nccl-version: 2.30.7-1
       hpcx-distribution: "hpcx-v2.50-gcc-doca_ofed-ubuntu22.04-cuda12"
 
@@ -53,8 +53,8 @@ jobs:
       folder: .
       dockerfile: Dockerfile
       base-image: nvidia/cuda
-      base-tag: 12.9.1-devel-ubuntu22.04
-      cuda-version: "12.9.1"
+      base-tag: 12.9.2-devel-ubuntu22.04
+      cuda-version: "12.9.2"
       nccl-version: 2.30.7-1
       hpcx-distribution: "hpcx-v2.50-gcc-doca_ofed-ubuntu22.04-cuda12"
 

--- a/.github/workflows/ubuntu-22.yml
+++ b/.github/workflows/ubuntu-22.yml
@@ -108,3 +108,20 @@ jobs:
       cuda-version: "13.2.1"
       nccl-version: 2.30.7-1
       hpcx-distribution: "hpcx-v2.50-gcc-doca_ofed-ubuntu22.04-cuda13"
+
+  cu133:
+    uses: ./.github/workflows/build.yml
+    secrets:
+      ORG_BUILDKIT_CLIENT_TOKEN: ${{ secrets.ORG_BUILDKIT_CLIENT_TOKEN }}
+      BUILDKIT_CONSUMER_DOPPLER_PROJECT: ${{ secrets.BUILDKIT_CONSUMER_DOPPLER_PROJECT }}
+      BUILDKIT_CONSUMER_ENDPOINT: ${{ secrets.BUILDKIT_CONSUMER_ENDPOINT }}
+      BUILDKIT_CONSUMER_AMD64_ENDPOINT: ${{ secrets.BUILDKIT_CONSUMER_AMD64_ENDPOINT }}
+      BUILDKIT_CONSUMER_ARM64_ENDPOINT: ${{ secrets.BUILDKIT_CONSUMER_ARM64_ENDPOINT }}
+    with:
+      folder: .
+      dockerfile: Dockerfile
+      base-image: nvidia/cuda
+      base-tag: 13.3.0-devel-ubuntu22.04
+      cuda-version: "13.3.0"
+      nccl-version: 2.30.7-1
+      hpcx-distribution: "hpcx-v2.50-gcc-doca_ofed-ubuntu22.04-cuda13"

--- a/.github/workflows/ubuntu-24.yml
+++ b/.github/workflows/ubuntu-24.yml
@@ -3,7 +3,7 @@ on:
   push:
     paths:
       - Dockerfile
-      - .github/workflows/ubuntu-22.yml
+      - .github/workflows/ubuntu-24.yml
       - .github/workflows/build.yml
 
 jobs:

--- a/.github/workflows/ubuntu-24.yml
+++ b/.github/workflows/ubuntu-24.yml
@@ -36,8 +36,8 @@ jobs:
       folder: .
       dockerfile: Dockerfile
       base-image: nvidia/cuda
-      base-tag: 13.0.2-devel-ubuntu24.04
-      cuda-version: "13.0.2"
+      base-tag: 13.0.3-devel-ubuntu24.04
+      cuda-version: "13.0.3"
       nccl-version: 2.30.7-1
       hpcx-distribution: "hpcx-v2.50-gcc-doca_ofed-ubuntu24.04-cuda13"
 
@@ -53,8 +53,8 @@ jobs:
       folder: .
       dockerfile: Dockerfile
       base-image: nvidia/cuda
-      base-tag: 13.1.1-devel-ubuntu24.04
-      cuda-version: "13.1.1"
+      base-tag: 13.1.2-devel-ubuntu24.04
+      cuda-version: "13.1.2"
       nccl-version: 2.30.7-1
       hpcx-distribution: "hpcx-v2.50-gcc-doca_ofed-ubuntu24.04-cuda13"
 

--- a/.github/workflows/ubuntu-24.yml
+++ b/.github/workflows/ubuntu-24.yml
@@ -19,8 +19,8 @@ jobs:
       folder: .
       dockerfile: Dockerfile
       base-image: nvidia/cuda
-      base-tag: 12.9.1-devel-ubuntu24.04
-      cuda-version: "12.9.1"
+      base-tag: 12.9.2-devel-ubuntu24.04
+      cuda-version: "12.9.2"
       nccl-version: 2.30.7-1
       hpcx-distribution: "hpcx-v2.50-gcc-doca_ofed-ubuntu24.04-cuda12"
 

--- a/.github/workflows/ubuntu-24.yml
+++ b/.github/workflows/ubuntu-24.yml
@@ -21,8 +21,8 @@ jobs:
       base-image: nvidia/cuda
       base-tag: 12.9.1-devel-ubuntu24.04
       cuda-version: "12.9.1"
-      nccl-version: 2.30.4-1
-      hpcx-distribution: "hpcx-v2.26-gcc-doca_ofed-ubuntu24.04-cuda12"
+      nccl-version: 2.30.7-1
+      hpcx-distribution: "hpcx-v2.50-gcc-doca_ofed-ubuntu24.04-cuda12"
 
   cu130:
     uses: ./.github/workflows/build.yml
@@ -38,8 +38,8 @@ jobs:
       base-image: nvidia/cuda
       base-tag: 13.0.2-devel-ubuntu24.04
       cuda-version: "13.0.2"
-      nccl-version: 2.30.4-1
-      hpcx-distribution: "hpcx-v2.26-gcc-doca_ofed-ubuntu24.04-cuda13"
+      nccl-version: 2.30.7-1
+      hpcx-distribution: "hpcx-v2.50-gcc-doca_ofed-ubuntu24.04-cuda13"
 
   cu131:
     uses: ./.github/workflows/build.yml
@@ -55,8 +55,8 @@ jobs:
       base-image: nvidia/cuda
       base-tag: 13.1.1-devel-ubuntu24.04
       cuda-version: "13.1.1"
-      nccl-version: 2.30.4-1
-      hpcx-distribution: "hpcx-v2.26-gcc-doca_ofed-ubuntu24.04-cuda13"
+      nccl-version: 2.30.7-1
+      hpcx-distribution: "hpcx-v2.50-gcc-doca_ofed-ubuntu24.04-cuda13"
 
   cu132:
     uses: ./.github/workflows/build.yml
@@ -72,5 +72,5 @@ jobs:
       base-image: nvidia/cuda
       base-tag: 13.2.1-devel-ubuntu24.04
       cuda-version: "13.2.1"
-      nccl-version: 2.30.4-1
-      hpcx-distribution: "hpcx-v2.26-gcc-doca_ofed-ubuntu24.04-cuda13"
+      nccl-version: 2.30.7-1
+      hpcx-distribution: "hpcx-v2.50-gcc-doca_ofed-ubuntu24.04-cuda13"

--- a/.github/workflows/ubuntu-24.yml
+++ b/.github/workflows/ubuntu-24.yml
@@ -74,3 +74,20 @@ jobs:
       cuda-version: "13.2.1"
       nccl-version: 2.30.7-1
       hpcx-distribution: "hpcx-v2.50-gcc-doca_ofed-ubuntu24.04-cuda13"
+
+  cu133:
+    uses: ./.github/workflows/build.yml
+    secrets:
+      ORG_BUILDKIT_CLIENT_TOKEN: ${{ secrets.ORG_BUILDKIT_CLIENT_TOKEN }}
+      BUILDKIT_CONSUMER_DOPPLER_PROJECT: ${{ secrets.BUILDKIT_CONSUMER_DOPPLER_PROJECT }}
+      BUILDKIT_CONSUMER_ENDPOINT: ${{ secrets.BUILDKIT_CONSUMER_ENDPOINT }}
+      BUILDKIT_CONSUMER_AMD64_ENDPOINT: ${{ secrets.BUILDKIT_CONSUMER_AMD64_ENDPOINT }}
+      BUILDKIT_CONSUMER_ARM64_ENDPOINT: ${{ secrets.BUILDKIT_CONSUMER_ARM64_ENDPOINT }}
+    with:
+      folder: .
+      dockerfile: Dockerfile
+      base-image: nvidia/cuda
+      base-tag: 13.3.0-devel-ubuntu24.04
+      cuda-version: "13.3.0"
+      nccl-version: 2.30.7-1
+      hpcx-distribution: "hpcx-v2.50-gcc-doca_ofed-ubuntu24.04-cuda13"

--- a/Dockerfile
+++ b/Dockerfile
@@ -74,7 +74,7 @@ RUN apt-get -qq update && \
 
 FROM builder-base AS libnccl2
 # NCCL
-ARG TARGET_NCCL_VERSION='2.30.4-1'
+ARG TARGET_NCCL_VERSION='2.30.7-1'
 ARG CUDA_ARCH_LIST='80 89 90 100 120'
 # Converts CUDA_ARCH_LIST to '-gencode=arch=compute_XX,code=sm_XX -gencode=...' format with PTX for the last listed arch
 RUN case "${CUDA_VERSION}" in 12.[0-7].*) \
@@ -155,7 +155,7 @@ RUN case "${CUDA_VERSION}" in 12.[0-7].*) \
 FROM builder-base AS hpcx
 # HPC-X
 # grep + sed is used as a workaround to update hardcoded pkg-config / libtools archive / CMake prefixes
-ARG HPCX_DISTRIBUTION="hpcx-v2.26-gcc-doca_ofed-ubuntu24.04-cuda12"
+ARG HPCX_DISTRIBUTION="hpcx-v2.50-gcc-doca_ofed-ubuntu24.04-cuda13"
 RUN cd /tmp && \
     DIST_NAME="${HPCX_DISTRIBUTION}-$(uname -m)" && \
     HPCX_DIR="/opt/hpcx" && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.7
 
-ARG CUDA_VERSION=13.2.1
+ARG CUDA_VERSION=13.3.0
 ARG BASE_IMAGE=nvidia/cuda:${CUDA_VERSION}-devel-ubuntu24.04
 FROM ${BASE_IMAGE} AS base
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ the following components:
 CoreWeave
 also [publishes images](https://github.com/coreweave/nccl-tests/pkgs/container/nccl-tests)
 built from these Dockerfiles that can be used as base for your own images.  
-The images below include **NCCL v2.30.4-1**, **HPC-X v2.26**,
+The images below include **NCCL v2.30.7-1**, **HPC-X v2.50**,
 and **cuDNN v9.20.0.48-1**.  
 Each image is multi-arch, and can be used for both `linux/amd64` and `linux/arm64` containers.
 Compute capabilities up to Blackwell (10.0 & 12.0) are supported.
@@ -73,21 +73,23 @@ Compute capabilities up to Blackwell (10.0 & 12.0) are supported.
 
 | **Image Tag**                                                              | **CUDA** |
 |----------------------------------------------------------------------------|----------|
-| ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.30.4-1-61f74e3 | 13.2.1   |
-| ghcr.io/coreweave/nccl-tests:13.1.1-devel-ubuntu24.04-nccl2.30.4-1-61f74e3 | 13.1.1   |
-| ghcr.io/coreweave/nccl-tests:13.0.2-devel-ubuntu24.04-nccl2.30.4-1-61f74e3 | 13.0.2   |
-| ghcr.io/coreweave/nccl-tests:12.9.1-devel-ubuntu24.04-nccl2.30.4-1-61f74e3 | 12.9.1   |
+| ghcr.io/coreweave/nccl-tests:13.3.0-devel-ubuntu24.04-nccl2.30.7-1-8b40b59 | 13.3.0   |
+| ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.30.7-1-8b40b59 | 13.2.1   |
+| ghcr.io/coreweave/nccl-tests:13.1.1-devel-ubuntu24.04-nccl2.30.7-1-8b40b59 | 13.1.1   |
+| ghcr.io/coreweave/nccl-tests:13.0.2-devel-ubuntu24.04-nccl2.30.7-1-8b40b59 | 13.0.2   |
+| ghcr.io/coreweave/nccl-tests:12.9.1-devel-ubuntu24.04-nccl2.30.7-1-8b40b59 | 12.9.1   |
 
 ### Ubuntu 22.04
 
 | **Image Tag**                                                              | **CUDA** |
 |----------------------------------------------------------------------------|----------|
-| ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu22.04-nccl2.30.4-1-61f74e3 | 13.2.1   |
-| ghcr.io/coreweave/nccl-tests:13.1.1-devel-ubuntu22.04-nccl2.30.4-1-61f74e3 | 13.1.1   |
-| ghcr.io/coreweave/nccl-tests:13.0.2-devel-ubuntu22.04-nccl2.30.4-1-61f74e3 | 13.0.2   |
-| ghcr.io/coreweave/nccl-tests:12.9.1-devel-ubuntu22.04-nccl2.30.4-1-61f74e3 | 12.9.1   |
-| ghcr.io/coreweave/nccl-tests:12.8.1-devel-ubuntu22.04-nccl2.30.4-1-61f74e3 | 12.8.1   |
-| ghcr.io/coreweave/nccl-tests:12.6.3-devel-ubuntu22.04-nccl2.30.4-1-61f74e3 | 12.6.3   |
+| ghcr.io/coreweave/nccl-tests:13.3.0-devel-ubuntu22.04-nccl2.30.7-1-8b40b59 | 13.3.0   |
+| ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu22.04-nccl2.30.7-1-8b40b59 | 13.2.1   |
+| ghcr.io/coreweave/nccl-tests:13.1.1-devel-ubuntu22.04-nccl2.30.7-1-8b40b59 | 13.1.1   |
+| ghcr.io/coreweave/nccl-tests:13.0.2-devel-ubuntu22.04-nccl2.30.7-1-8b40b59 | 13.0.2   |
+| ghcr.io/coreweave/nccl-tests:12.9.1-devel-ubuntu22.04-nccl2.30.7-1-8b40b59 | 12.9.1   |
+| ghcr.io/coreweave/nccl-tests:12.8.1-devel-ubuntu22.04-nccl2.30.7-1-8b40b59 | 12.8.1   |
+| ghcr.io/coreweave/nccl-tests:12.6.3-devel-ubuntu22.04-nccl2.30.7-1-8b40b59 | 12.6.3   |
 
 ## Running NCCL Tests
 

--- a/README.md
+++ b/README.md
@@ -73,23 +73,23 @@ Compute capabilities up to Blackwell (10.0 & 12.0) are supported.
 
 | **Image Tag**                                                              | **CUDA** |
 |----------------------------------------------------------------------------|----------|
-| ghcr.io/coreweave/nccl-tests:13.3.0-devel-ubuntu24.04-nccl2.30.7-1-8b40b59 | 13.3.0   |
-| ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.30.7-1-8b40b59 | 13.2.1   |
-| ghcr.io/coreweave/nccl-tests:13.1.1-devel-ubuntu24.04-nccl2.30.7-1-8b40b59 | 13.1.1   |
-| ghcr.io/coreweave/nccl-tests:13.0.2-devel-ubuntu24.04-nccl2.30.7-1-8b40b59 | 13.0.2   |
-| ghcr.io/coreweave/nccl-tests:12.9.1-devel-ubuntu24.04-nccl2.30.7-1-8b40b59 | 12.9.1   |
+| ghcr.io/coreweave/nccl-tests:13.3.0-devel-ubuntu24.04-nccl2.30.7-1-00fed36 | 13.3.0   |
+| ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.30.7-1-00fed36 | 13.2.1   |
+| ghcr.io/coreweave/nccl-tests:13.1.2-devel-ubuntu24.04-nccl2.30.7-1-00fed36 | 13.1.2   |
+| ghcr.io/coreweave/nccl-tests:13.0.3-devel-ubuntu24.04-nccl2.30.7-1-00fed36 | 13.0.3   |
+| ghcr.io/coreweave/nccl-tests:12.9.2-devel-ubuntu24.04-nccl2.30.7-1-00fed36 | 12.9.2   |
 
 ### Ubuntu 22.04
 
 | **Image Tag**                                                              | **CUDA** |
 |----------------------------------------------------------------------------|----------|
-| ghcr.io/coreweave/nccl-tests:13.3.0-devel-ubuntu22.04-nccl2.30.7-1-8b40b59 | 13.3.0   |
-| ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu22.04-nccl2.30.7-1-8b40b59 | 13.2.1   |
-| ghcr.io/coreweave/nccl-tests:13.1.1-devel-ubuntu22.04-nccl2.30.7-1-8b40b59 | 13.1.1   |
-| ghcr.io/coreweave/nccl-tests:13.0.2-devel-ubuntu22.04-nccl2.30.7-1-8b40b59 | 13.0.2   |
-| ghcr.io/coreweave/nccl-tests:12.9.1-devel-ubuntu22.04-nccl2.30.7-1-8b40b59 | 12.9.1   |
-| ghcr.io/coreweave/nccl-tests:12.8.1-devel-ubuntu22.04-nccl2.30.7-1-8b40b59 | 12.8.1   |
-| ghcr.io/coreweave/nccl-tests:12.6.3-devel-ubuntu22.04-nccl2.30.7-1-8b40b59 | 12.6.3   |
+| ghcr.io/coreweave/nccl-tests:13.3.0-devel-ubuntu22.04-nccl2.30.7-1-00fed36 | 13.3.0   |
+| ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu22.04-nccl2.30.7-1-00fed36 | 13.2.1   |
+| ghcr.io/coreweave/nccl-tests:13.1.2-devel-ubuntu22.04-nccl2.30.7-1-00fed36 | 13.1.2   |
+| ghcr.io/coreweave/nccl-tests:13.0.3-devel-ubuntu22.04-nccl2.30.7-1-00fed36 | 13.0.3   |
+| ghcr.io/coreweave/nccl-tests:12.9.2-devel-ubuntu22.04-nccl2.30.7-1-00fed36 | 12.9.2   |
+| ghcr.io/coreweave/nccl-tests:12.8.2-devel-ubuntu22.04-nccl2.30.7-1-00fed36 | 12.8.2   |
+| ghcr.io/coreweave/nccl-tests:12.6.3-devel-ubuntu22.04-nccl2.30.7-1-00fed36 | 12.6.3   |
 
 ## Running NCCL Tests
 


### PR DESCRIPTION
# Updates for NCCL, HPC-X, & CUDA

This change updates the following components:

- NCCL [2.30.4-1](https://github.com/NVIDIA/nccl/releases/tag/v2.30.4-1) → [2.30.7-1](https://github.com/NVIDIA/nccl/releases/tag/v2.30.7-1)
- HPC-X 2.26 → 2.50
- ∅ → CUDA 13.3.0
- CUDA 13.1.1 → 13.1.2
- CUDA 13.0.2 → 13.0.3
- CUDA 12.9.1 → 12.9.2
- CUDA 12.8.1 → 12.8.2