### PR TITLE
feat: Update NCCL to 2.31.2-1

### DIFF
--- a/.github/workflows/ubuntu-22.yml
+++ b/.github/workflows/ubuntu-22.yml
@@ -21,7 +21,7 @@ jobs:
       base-image: nvidia/cuda
       base-tag: 12.6.3-devel-ubuntu22.04
       cuda-version: "12.6.3"
-      nccl-version: 2.30.7-1
+      nccl-version: 2.31.2-1
       hpcx-distribution: "hpcx-v2.50-gcc-doca_ofed-ubuntu22.04-cuda12"
 
   cu128:
@@ -38,7 +38,7 @@ jobs:
       base-image: nvidia/cuda
       base-tag: 12.8.2-devel-ubuntu22.04
       cuda-version: "12.8.2"
-      nccl-version: 2.30.7-1
+      nccl-version: 2.31.2-1
       hpcx-distribution: "hpcx-v2.50-gcc-doca_ofed-ubuntu22.04-cuda12"
 
   cu129:
@@ -55,7 +55,7 @@ jobs:
       base-image: nvidia/cuda
       base-tag: 12.9.2-devel-ubuntu22.04
       cuda-version: "12.9.2"
-      nccl-version: 2.30.7-1
+      nccl-version: 2.31.2-1
       hpcx-distribution: "hpcx-v2.50-gcc-doca_ofed-ubuntu22.04-cuda12"
 
   cu130:
@@ -72,7 +72,7 @@ jobs:
       base-image: nvidia/cuda
       base-tag: 13.0.3-devel-ubuntu22.04
       cuda-version: "13.0.3"
-      nccl-version: 2.30.7-1
+      nccl-version: 2.31.2-1
       hpcx-distribution: "hpcx-v2.50-gcc-doca_ofed-ubuntu22.04-cuda13"
 
   cu131:
@@ -89,7 +89,7 @@ jobs:
       base-image: nvidia/cuda
       base-tag: 13.1.2-devel-ubuntu22.04
       cuda-version: "13.1.2"
-      nccl-version: 2.30.7-1
+      nccl-version: 2.31.2-1
       hpcx-distribution: "hpcx-v2.50-gcc-doca_ofed-ubuntu22.04-cuda13"
 
   cu132:
@@ -106,7 +106,7 @@ jobs:
       base-image: nvidia/cuda
       base-tag: 13.2.1-devel-ubuntu22.04
       cuda-version: "13.2.1"
-      nccl-version: 2.30.7-1
+      nccl-version: 2.31.2-1
       hpcx-distribution: "hpcx-v2.50-gcc-doca_ofed-ubuntu22.04-cuda13"
 
   cu133:
@@ -123,5 +123,5 @@ jobs:
       base-image: nvidia/cuda
       base-tag: 13.3.0-devel-ubuntu22.04
       cuda-version: "13.3.0"
-      nccl-version: 2.30.7-1
+      nccl-version: 2.31.2-1
       hpcx-distribution: "hpcx-v2.50-gcc-doca_ofed-ubuntu22.04-cuda13"

--- a/.github/workflows/ubuntu-24.yml
+++ b/.github/workflows/ubuntu-24.yml
@@ -21,7 +21,7 @@ jobs:
       base-image: nvidia/cuda
       base-tag: 12.9.2-devel-ubuntu24.04
       cuda-version: "12.9.2"
-      nccl-version: 2.30.7-1
+      nccl-version: 2.31.2-1
       hpcx-distribution: "hpcx-v2.50-gcc-doca_ofed-ubuntu24.04-cuda12"
 
   cu130:
@@ -38,7 +38,7 @@ jobs:
       base-image: nvidia/cuda
       base-tag: 13.0.3-devel-ubuntu24.04
       cuda-version: "13.0.3"
-      nccl-version: 2.30.7-1
+      nccl-version: 2.31.2-1
       hpcx-distribution: "hpcx-v2.50-gcc-doca_ofed-ubuntu24.04-cuda13"
 
   cu131:
@@ -55,7 +55,7 @@ jobs:
       base-image: nvidia/cuda
       base-tag: 13.1.2-devel-ubuntu24.04
       cuda-version: "13.1.2"
-      nccl-version: 2.30.7-1
+      nccl-version: 2.31.2-1
       hpcx-distribution: "hpcx-v2.50-gcc-doca_ofed-ubuntu24.04-cuda13"
 
   cu132:
@@ -72,7 +72,7 @@ jobs:
       base-image: nvidia/cuda
       base-tag: 13.2.1-devel-ubuntu24.04
       cuda-version: "13.2.1"
-      nccl-version: 2.30.7-1
+      nccl-version: 2.31.2-1
       hpcx-distribution: "hpcx-v2.50-gcc-doca_ofed-ubuntu24.04-cuda13"
 
   cu133:
@@ -89,5 +89,5 @@ jobs:
       base-image: nvidia/cuda
       base-tag: 13.3.0-devel-ubuntu24.04
       cuda-version: "13.3.0"
-      nccl-version: 2.30.7-1
+      nccl-version: 2.31.2-1
       hpcx-distribution: "hpcx-v2.50-gcc-doca_ofed-ubuntu24.04-cuda13"

--- a/Dockerfile
+++ b/Dockerfile
@@ -74,7 +74,7 @@ RUN apt-get -qq update && \
 
 FROM builder-base AS libnccl2
 # NCCL
-ARG TARGET_NCCL_VERSION='2.30.7-1'
+ARG TARGET_NCCL_VERSION='2.31.2-1'
 ARG CUDA_ARCH_LIST='80 89 90 100 120'
 # Converts CUDA_ARCH_LIST to '-gencode=arch=compute_XX,code=sm_XX -gencode=...' format with PTX for the last listed arch
 RUN case "${CUDA_VERSION}" in 12.[0-7].*) \

--- a/README.md
+++ b/README.md
@@ -73,23 +73,23 @@ Compute capabilities up to Blackwell (10.0 & 12.0) are supported.
 
 | **Image Tag**                                                              | **CUDA** |
 |----------------------------------------------------------------------------|----------|
-| ghcr.io/coreweave/nccl-tests:13.3.0-devel-ubuntu24.04-nccl2.30.7-1-00fed36 | 13.3.0   |
-| ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.30.7-1-00fed36 | 13.2.1   |
-| ghcr.io/coreweave/nccl-tests:13.1.2-devel-ubuntu24.04-nccl2.30.7-1-00fed36 | 13.1.2   |
-| ghcr.io/coreweave/nccl-tests:13.0.3-devel-ubuntu24.04-nccl2.30.7-1-00fed36 | 13.0.3   |
-| ghcr.io/coreweave/nccl-tests:12.9.2-devel-ubuntu24.04-nccl2.30.7-1-00fed36 | 12.9.2   |
+| ghcr.io/coreweave/nccl-tests:13.3.0-devel-ubuntu24.04-nccl2.31.2-1-ee0d4d1 | 13.3.0   |
+| ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.31.2-1-ee0d4d1 | 13.2.1   |
+| ghcr.io/coreweave/nccl-tests:13.1.2-devel-ubuntu24.04-nccl2.31.2-1-ee0d4d1 | 13.1.2   |
+| ghcr.io/coreweave/nccl-tests:13.0.3-devel-ubuntu24.04-nccl2.31.2-1-ee0d4d1 | 13.0.3   |
+| ghcr.io/coreweave/nccl-tests:12.9.2-devel-ubuntu24.04-nccl2.31.2-1-ee0d4d1 | 12.9.2   |
 
 ### Ubuntu 22.04
 
 | **Image Tag**                                                              | **CUDA** |
 |----------------------------------------------------------------------------|----------|
-| ghcr.io/coreweave/nccl-tests:13.3.0-devel-ubuntu22.04-nccl2.30.7-1-00fed36 | 13.3.0   |
-| ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu22.04-nccl2.30.7-1-00fed36 | 13.2.1   |
-| ghcr.io/coreweave/nccl-tests:13.1.2-devel-ubuntu22.04-nccl2.30.7-1-00fed36 | 13.1.2   |
-| ghcr.io/coreweave/nccl-tests:13.0.3-devel-ubuntu22.04-nccl2.30.7-1-00fed36 | 13.0.3   |
-| ghcr.io/coreweave/nccl-tests:12.9.2-devel-ubuntu22.04-nccl2.30.7-1-00fed36 | 12.9.2   |
-| ghcr.io/coreweave/nccl-tests:12.8.2-devel-ubuntu22.04-nccl2.30.7-1-00fed36 | 12.8.2   |
-| ghcr.io/coreweave/nccl-tests:12.6.3-devel-ubuntu22.04-nccl2.30.7-1-00fed36 | 12.6.3   |
+| ghcr.io/coreweave/nccl-tests:13.3.0-devel-ubuntu22.04-nccl2.31.2-1-ee0d4d1 | 13.3.0   |
+| ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu22.04-nccl2.31.2-1-ee0d4d1 | 13.2.1   |
+| ghcr.io/coreweave/nccl-tests:13.1.2-devel-ubuntu22.04-nccl2.31.2-1-ee0d4d1 | 13.1.2   |
+| ghcr.io/coreweave/nccl-tests:13.0.3-devel-ubuntu22.04-nccl2.31.2-1-ee0d4d1 | 13.0.3   |
+| ghcr.io/coreweave/nccl-tests:12.9.2-devel-ubuntu22.04-nccl2.31.2-1-ee0d4d1 | 12.9.2   |
+| ghcr.io/coreweave/nccl-tests:12.8.2-devel-ubuntu22.04-nccl2.31.2-1-ee0d4d1 | 12.8.2   |
+| ghcr.io/coreweave/nccl-tests:12.6.3-devel-ubuntu22.04-nccl2.31.2-1-ee0d4d1 | 12.6.3   |
 
 ## Running NCCL Tests
 


### PR DESCRIPTION
# NCCL 2.31.2-1

This change updates NCCL from version [2.30.7-1](https://github.com/NVIDIA/nccl/releases/tag/v2.30.7-1) to [2.31.2-1](https://github.com/NVIDIA/nccl/releases/tag/v2.31.2-1).