### PR TITLE
Update NCCL version in examples and enable SPCX plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,23 +73,23 @@ Compute capabilities up to Blackwell (10.0 & 12.0) are supported.
 
 | **Image Tag**                                                              | **CUDA** |
 |----------------------------------------------------------------------------|----------|
-| ghcr.io/coreweave/nccl-tests:13.3.0-devel-ubuntu24.04-nccl2.31.2-1-d08cf2b | 13.3.0   |
-| ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.31.2-1-d08cf2b | 13.2.1   |
-| ghcr.io/coreweave/nccl-tests:13.1.2-devel-ubuntu24.04-nccl2.31.2-1-d08cf2b | 13.1.2   |
-| ghcr.io/coreweave/nccl-tests:13.0.3-devel-ubuntu24.04-nccl2.31.2-1-d08cf2b | 13.0.3   |
-| ghcr.io/coreweave/nccl-tests:12.9.2-devel-ubuntu24.04-nccl2.31.2-1-d08cf2b | 12.9.2   |
+| ghcr.io/coreweave/nccl-tests:13.3.0-devel-ubuntu24.04-nccl2.31.2-1-ee0d4d1 | 13.3.0   |
+| ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.31.2-1-ee0d4d1 | 13.2.1   |
+| ghcr.io/coreweave/nccl-tests:13.1.2-devel-ubuntu24.04-nccl2.31.2-1-ee0d4d1 | 13.1.2   |
+| ghcr.io/coreweave/nccl-tests:13.0.3-devel-ubuntu24.04-nccl2.31.2-1-ee0d4d1 | 13.0.3   |
+| ghcr.io/coreweave/nccl-tests:12.9.2-devel-ubuntu24.04-nccl2.31.2-1-ee0d4d1 | 12.9.2   |
 
 ### Ubuntu 22.04
 
 | **Image Tag**                                                              | **CUDA** |
 |----------------------------------------------------------------------------|----------|
-| ghcr.io/coreweave/nccl-tests:13.3.0-devel-ubuntu22.04-nccl2.31.2-1-d08cf2b | 13.3.0   |
-| ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu22.04-nccl2.31.2-1-d08cf2b | 13.2.1   |
-| ghcr.io/coreweave/nccl-tests:13.1.2-devel-ubuntu22.04-nccl2.31.2-1-d08cf2b | 13.1.2   |
-| ghcr.io/coreweave/nccl-tests:13.0.3-devel-ubuntu22.04-nccl2.31.2-1-d08cf2b | 13.0.3   |
-| ghcr.io/coreweave/nccl-tests:12.9.2-devel-ubuntu22.04-nccl2.31.2-1-d08cf2b | 12.9.2   |
-| ghcr.io/coreweave/nccl-tests:12.8.2-devel-ubuntu22.04-nccl2.31.2-1-d08cf2b | 12.8.2   |
-| ghcr.io/coreweave/nccl-tests:12.6.3-devel-ubuntu22.04-nccl2.31.2-1-d08cf2b | 12.6.3   |
+| ghcr.io/coreweave/nccl-tests:13.3.0-devel-ubuntu22.04-nccl2.31.2-1-ee0d4d1 | 13.3.0   |
+| ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu22.04-nccl2.31.2-1-ee0d4d1 | 13.2.1   |
+| ghcr.io/coreweave/nccl-tests:13.1.2-devel-ubuntu22.04-nccl2.31.2-1-ee0d4d1 | 13.1.2   |
+| ghcr.io/coreweave/nccl-tests:13.0.3-devel-ubuntu22.04-nccl2.31.2-1-ee0d4d1 | 13.0.3   |
+| ghcr.io/coreweave/nccl-tests:12.9.2-devel-ubuntu22.04-nccl2.31.2-1-ee0d4d1 | 12.9.2   |
+| ghcr.io/coreweave/nccl-tests:12.8.2-devel-ubuntu22.04-nccl2.31.2-1-ee0d4d1 | 12.8.2   |
+| ghcr.io/coreweave/nccl-tests:12.6.3-devel-ubuntu22.04-nccl2.31.2-1-ee0d4d1 | 12.6.3   |
 
 ## Running NCCL Tests
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ the following components:
 CoreWeave
 also [publishes images](https://github.com/coreweave/nccl-tests/pkgs/container/nccl-tests)
 built from these Dockerfiles that can be used as base for your own images.  
-The images below include **NCCL v2.30.7-1**, **HPC-X v2.50**,
+The images below include **NCCL v2.31.2-1**, **HPC-X v2.50**,
 and **cuDNN v9.20.0.48-1**.  
 Each image is multi-arch, and can be used for both `linux/amd64` and `linux/arm64` containers.
 Compute capabilities up to Blackwell (10.0 & 12.0) are supported.
@@ -73,23 +73,23 @@ Compute capabilities up to Blackwell (10.0 & 12.0) are supported.
 
 | **Image Tag**                                                              | **CUDA** |
 |----------------------------------------------------------------------------|----------|
-| ghcr.io/coreweave/nccl-tests:13.3.0-devel-ubuntu24.04-nccl2.31.2-1-ee0d4d1 | 13.3.0   |
-| ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.31.2-1-ee0d4d1 | 13.2.1   |
-| ghcr.io/coreweave/nccl-tests:13.1.2-devel-ubuntu24.04-nccl2.31.2-1-ee0d4d1 | 13.1.2   |
-| ghcr.io/coreweave/nccl-tests:13.0.3-devel-ubuntu24.04-nccl2.31.2-1-ee0d4d1 | 13.0.3   |
-| ghcr.io/coreweave/nccl-tests:12.9.2-devel-ubuntu24.04-nccl2.31.2-1-ee0d4d1 | 12.9.2   |
+| ghcr.io/coreweave/nccl-tests:13.3.0-devel-ubuntu24.04-nccl2.31.2-1-d08cf2b | 13.3.0   |
+| ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.31.2-1-d08cf2b | 13.2.1   |
+| ghcr.io/coreweave/nccl-tests:13.1.2-devel-ubuntu24.04-nccl2.31.2-1-d08cf2b | 13.1.2   |
+| ghcr.io/coreweave/nccl-tests:13.0.3-devel-ubuntu24.04-nccl2.31.2-1-d08cf2b | 13.0.3   |
+| ghcr.io/coreweave/nccl-tests:12.9.2-devel-ubuntu24.04-nccl2.31.2-1-d08cf2b | 12.9.2   |
 
 ### Ubuntu 22.04
 
 | **Image Tag**                                                              | **CUDA** |
 |----------------------------------------------------------------------------|----------|
-| ghcr.io/coreweave/nccl-tests:13.3.0-devel-ubuntu22.04-nccl2.31.2-1-ee0d4d1 | 13.3.0   |
-| ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu22.04-nccl2.31.2-1-ee0d4d1 | 13.2.1   |
-| ghcr.io/coreweave/nccl-tests:13.1.2-devel-ubuntu22.04-nccl2.31.2-1-ee0d4d1 | 13.1.2   |
-| ghcr.io/coreweave/nccl-tests:13.0.3-devel-ubuntu22.04-nccl2.31.2-1-ee0d4d1 | 13.0.3   |
-| ghcr.io/coreweave/nccl-tests:12.9.2-devel-ubuntu22.04-nccl2.31.2-1-ee0d4d1 | 12.9.2   |
-| ghcr.io/coreweave/nccl-tests:12.8.2-devel-ubuntu22.04-nccl2.31.2-1-ee0d4d1 | 12.8.2   |
-| ghcr.io/coreweave/nccl-tests:12.6.3-devel-ubuntu22.04-nccl2.31.2-1-ee0d4d1 | 12.6.3   |
+| ghcr.io/coreweave/nccl-tests:13.3.0-devel-ubuntu22.04-nccl2.31.2-1-d08cf2b | 13.3.0   |
+| ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu22.04-nccl2.31.2-1-d08cf2b | 13.2.1   |
+| ghcr.io/coreweave/nccl-tests:13.1.2-devel-ubuntu22.04-nccl2.31.2-1-d08cf2b | 13.1.2   |
+| ghcr.io/coreweave/nccl-tests:13.0.3-devel-ubuntu22.04-nccl2.31.2-1-d08cf2b | 13.0.3   |
+| ghcr.io/coreweave/nccl-tests:12.9.2-devel-ubuntu22.04-nccl2.31.2-1-d08cf2b | 12.9.2   |
+| ghcr.io/coreweave/nccl-tests:12.8.2-devel-ubuntu22.04-nccl2.31.2-1-d08cf2b | 12.8.2   |
+| ghcr.io/coreweave/nccl-tests:12.6.3-devel-ubuntu22.04-nccl2.31.2-1-d08cf2b | 12.6.3   |
 
 ## Running NCCL Tests
 

--- a/mpi-operator/nccl-test-distributed-a100-64-gdrcopy-mpijob.yaml
+++ b/mpi-operator/nccl-test-distributed-a100-64-gdrcopy-mpijob.yaml
@@ -12,7 +12,7 @@ spec:
       template:
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:13.3.0-devel-ubuntu24.04-nccl2.31.2-1-d08cf2b
+            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.31.2-1-ee0d4d1
               name: nccl
               env:
                 - name: OMPI_ALLOW_RUN_AS_ROOT
@@ -44,7 +44,7 @@ spec:
       template:
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:13.3.0-devel-ubuntu24.04-nccl2.31.2-1-d08cf2b
+            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.31.2-1-ee0d4d1
               name: nccl
               resources:
                 requests:

--- a/mpi-operator/nccl-test-distributed-a100-64-gdrcopy-mpijob.yaml
+++ b/mpi-operator/nccl-test-distributed-a100-64-gdrcopy-mpijob.yaml
@@ -12,7 +12,7 @@ spec:
       template:
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu22.04-nccl2.30.4-1-2eedd7c
+            - image: ghcr.io/coreweave/nccl-tests:13.3.0-devel-ubuntu24.04-nccl2.31.2-1-d08cf2b
               name: nccl
               env:
                 - name: OMPI_ALLOW_RUN_AS_ROOT
@@ -44,7 +44,7 @@ spec:
       template:
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu22.04-nccl2.30.4-1-2eedd7c
+            - image: ghcr.io/coreweave/nccl-tests:13.3.0-devel-ubuntu24.04-nccl2.31.2-1-d08cf2b
               name: nccl
               resources:
                 requests:

--- a/mpi-operator/nccl-test-distributed-a100-64-mpijob.yaml
+++ b/mpi-operator/nccl-test-distributed-a100-64-mpijob.yaml
@@ -12,7 +12,7 @@ spec:
       template:
           spec:
             containers:
-            - image: ghcr.io/coreweave/nccl-tests:13.3.0-devel-ubuntu24.04-nccl2.31.2-1-d08cf2b
+            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.31.2-1-ee0d4d1
               name: nccl
               env:
               - name: OMPI_ALLOW_RUN_AS_ROOT
@@ -45,7 +45,7 @@ spec:
             metadata.coreweave.cloud/job: nccl-test
         spec:
           containers:
-          - image: ghcr.io/coreweave/nccl-tests:13.3.0-devel-ubuntu24.04-nccl2.31.2-1-d08cf2b
+          - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.31.2-1-ee0d4d1
             name: nccl
             resources:
               requests:

--- a/mpi-operator/nccl-test-distributed-a100-64-mpijob.yaml
+++ b/mpi-operator/nccl-test-distributed-a100-64-mpijob.yaml
@@ -12,7 +12,7 @@ spec:
       template:
           spec:
             containers:
-            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu22.04-nccl2.30.4-1-2eedd7c
+            - image: ghcr.io/coreweave/nccl-tests:13.3.0-devel-ubuntu24.04-nccl2.31.2-1-d08cf2b
               name: nccl
               env:
               - name: OMPI_ALLOW_RUN_AS_ROOT
@@ -45,7 +45,7 @@ spec:
             metadata.coreweave.cloud/job: nccl-test
         spec:
           containers:
-          - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu22.04-nccl2.30.4-1-2eedd7c
+          - image: ghcr.io/coreweave/nccl-tests:13.3.0-devel-ubuntu24.04-nccl2.31.2-1-d08cf2b
             name: nccl
             resources:
               requests:

--- a/mpi-operator/nccl-test-distributed-a100-64-noib-mpijob.yaml
+++ b/mpi-operator/nccl-test-distributed-a100-64-noib-mpijob.yaml
@@ -12,7 +12,7 @@ spec:
       template:
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu22.04-nccl2.30.4-1-2eedd7c
+            - image: ghcr.io/coreweave/nccl-tests:13.3.0-devel-ubuntu24.04-nccl2.31.2-1-d08cf2b
               name: nccl
               env:
                 - name: OMPI_ALLOW_RUN_AS_ROOT
@@ -47,7 +47,7 @@ spec:
             metadata.coreweave.cloud/job: nccl-test
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu22.04-nccl2.30.4-1-2eedd7c
+            - image: ghcr.io/coreweave/nccl-tests:13.3.0-devel-ubuntu24.04-nccl2.31.2-1-d08cf2b
               name: nccl
               resources:
                 requests:

--- a/mpi-operator/nccl-test-distributed-a100-64-noib-mpijob.yaml
+++ b/mpi-operator/nccl-test-distributed-a100-64-noib-mpijob.yaml
@@ -12,7 +12,7 @@ spec:
       template:
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:13.3.0-devel-ubuntu24.04-nccl2.31.2-1-d08cf2b
+            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.31.2-1-ee0d4d1
               name: nccl
               env:
                 - name: OMPI_ALLOW_RUN_AS_ROOT
@@ -47,7 +47,7 @@ spec:
             metadata.coreweave.cloud/job: nccl-test
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:13.3.0-devel-ubuntu24.04-nccl2.31.2-1-d08cf2b
+            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.31.2-1-ee0d4d1
               name: nccl
               resources:
                 requests:

--- a/mpi-operator/nccl-test-distributed-a100-64-sharp-mpijob.yaml
+++ b/mpi-operator/nccl-test-distributed-a100-64-sharp-mpijob.yaml
@@ -12,7 +12,7 @@ spec:
       template:
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:13.3.0-devel-ubuntu24.04-nccl2.31.2-1-d08cf2b
+            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.31.2-1-ee0d4d1
               name: nccl
               env:
                 - name: OMPI_ALLOW_RUN_AS_ROOT
@@ -48,7 +48,7 @@ spec:
             metadata.coreweave.cloud/job: nccl-test
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:13.3.0-devel-ubuntu24.04-nccl2.31.2-1-d08cf2b
+            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.31.2-1-ee0d4d1
               name: nccl
               resources:
                 requests:

--- a/mpi-operator/nccl-test-distributed-a100-64-sharp-mpijob.yaml
+++ b/mpi-operator/nccl-test-distributed-a100-64-sharp-mpijob.yaml
@@ -12,7 +12,7 @@ spec:
       template:
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu22.04-nccl2.30.4-1-2eedd7c
+            - image: ghcr.io/coreweave/nccl-tests:13.3.0-devel-ubuntu24.04-nccl2.31.2-1-d08cf2b
               name: nccl
               env:
                 - name: OMPI_ALLOW_RUN_AS_ROOT
@@ -48,7 +48,7 @@ spec:
             metadata.coreweave.cloud/job: nccl-test
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu22.04-nccl2.30.4-1-2eedd7c
+            - image: ghcr.io/coreweave/nccl-tests:13.3.0-devel-ubuntu24.04-nccl2.31.2-1-d08cf2b
               name: nccl
               resources:
                 requests:

--- a/mpi-operator/nccl-test-distributed-a40-64-mpijob.yaml
+++ b/mpi-operator/nccl-test-distributed-a40-64-mpijob.yaml
@@ -12,7 +12,7 @@ spec:
       template:
           spec:
             containers:
-            - image: ghcr.io/coreweave/nccl-tests:13.3.0-devel-ubuntu24.04-nccl2.31.2-1-d08cf2b
+            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.31.2-1-ee0d4d1
               name: nccl
               env:
               - name: OMPI_ALLOW_RUN_AS_ROOT
@@ -42,7 +42,7 @@ spec:
       template:
         spec:
           containers:
-          - image: ghcr.io/coreweave/nccl-tests:13.3.0-devel-ubuntu24.04-nccl2.31.2-1-d08cf2b
+          - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.31.2-1-ee0d4d1
             name: nccl
             resources:
               requests:

--- a/mpi-operator/nccl-test-distributed-a40-64-mpijob.yaml
+++ b/mpi-operator/nccl-test-distributed-a40-64-mpijob.yaml
@@ -12,7 +12,7 @@ spec:
       template:
           spec:
             containers:
-            - image: ghcr.io/coreweave/nccl-tests:12.4.1-cudnn-devel-ubuntu20.04-nccl2.21.5-1-85f9143
+            - image: ghcr.io/coreweave/nccl-tests:13.3.0-devel-ubuntu24.04-nccl2.31.2-1-d08cf2b
               name: nccl
               env:
               - name: OMPI_ALLOW_RUN_AS_ROOT
@@ -42,7 +42,7 @@ spec:
       template:
         spec:
           containers:
-          - image: ghcr.io/coreweave/nccl-tests:12.4.1-cudnn-devel-ubuntu20.04-nccl2.21.5-1-85f9143
+          - image: ghcr.io/coreweave/nccl-tests:13.3.0-devel-ubuntu24.04-nccl2.31.2-1-d08cf2b
             name: nccl
             resources:
               requests:

--- a/mpi-operator/nccl-test-distributed-b200-64-mpijob.yaml
+++ b/mpi-operator/nccl-test-distributed-b200-64-mpijob.yaml
@@ -12,7 +12,7 @@ spec:
       template:
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:13.3.0-devel-ubuntu24.04-nccl2.31.2-1-d08cf2b
+            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.31.2-1-ee0d4d1
               name: nccl
               env:
                 - name: OMPI_ALLOW_RUN_AS_ROOT
@@ -49,7 +49,7 @@ spec:
             metadata.coreweave.cloud/job: nccl-test
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:13.3.0-devel-ubuntu24.04-nccl2.31.2-1-d08cf2b
+            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.31.2-1-ee0d4d1
               name: nccl
               resources:
                 requests:

--- a/mpi-operator/nccl-test-distributed-b200-64-mpijob.yaml
+++ b/mpi-operator/nccl-test-distributed-b200-64-mpijob.yaml
@@ -12,7 +12,7 @@ spec:
       template:
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu22.04-nccl2.30.4-1-2eedd7c
+            - image: ghcr.io/coreweave/nccl-tests:13.3.0-devel-ubuntu24.04-nccl2.31.2-1-d08cf2b
               name: nccl
               env:
                 - name: OMPI_ALLOW_RUN_AS_ROOT
@@ -49,7 +49,7 @@ spec:
             metadata.coreweave.cloud/job: nccl-test
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu22.04-nccl2.30.4-1-2eedd7c
+            - image: ghcr.io/coreweave/nccl-tests:13.3.0-devel-ubuntu24.04-nccl2.31.2-1-d08cf2b
               name: nccl
               resources:
                 requests:

--- a/mpi-operator/nccl-test-distributed-b200-64-sharp-mpijob.yaml
+++ b/mpi-operator/nccl-test-distributed-b200-64-sharp-mpijob.yaml
@@ -12,7 +12,7 @@ spec:
       template:
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:13.3.0-devel-ubuntu24.04-nccl2.31.2-1-d08cf2b
+            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.31.2-1-ee0d4d1
               name: nccl
               env:
                 - name: OMPI_ALLOW_RUN_AS_ROOT
@@ -49,7 +49,7 @@ spec:
             metadata.coreweave.cloud/job: nccl-test
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:13.3.0-devel-ubuntu24.04-nccl2.31.2-1-d08cf2b
+            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.31.2-1-ee0d4d1
               name: nccl
               resources:
                 requests:

--- a/mpi-operator/nccl-test-distributed-b200-64-sharp-mpijob.yaml
+++ b/mpi-operator/nccl-test-distributed-b200-64-sharp-mpijob.yaml
@@ -12,7 +12,7 @@ spec:
       template:
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu22.04-nccl2.30.4-1-2eedd7c
+            - image: ghcr.io/coreweave/nccl-tests:13.3.0-devel-ubuntu24.04-nccl2.31.2-1-d08cf2b
               name: nccl
               env:
                 - name: OMPI_ALLOW_RUN_AS_ROOT
@@ -49,7 +49,7 @@ spec:
             metadata.coreweave.cloud/job: nccl-test
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu22.04-nccl2.30.4-1-2eedd7c
+            - image: ghcr.io/coreweave/nccl-tests:13.3.0-devel-ubuntu24.04-nccl2.31.2-1-d08cf2b
               name: nccl
               resources:
                 requests:

--- a/mpi-operator/nccl-test-distributed-b300-64-mpijob.yaml
+++ b/mpi-operator/nccl-test-distributed-b300-64-mpijob.yaml
@@ -12,7 +12,7 @@ spec:
       template:
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:13.3.0-devel-ubuntu24.04-nccl2.31.2-1-d08cf2b
+            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.31.2-1-ee0d4d1
               name: nccl
               env:
                 - name: OMPI_ALLOW_RUN_AS_ROOT
@@ -49,7 +49,7 @@ spec:
             metadata.coreweave.cloud/job: nccl-test
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:13.3.0-devel-ubuntu24.04-nccl2.31.2-1-d08cf2b
+            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.31.2-1-ee0d4d1
               name: nccl
               resources:
                 requests:

--- a/mpi-operator/nccl-test-distributed-b300-64-mpijob.yaml
+++ b/mpi-operator/nccl-test-distributed-b300-64-mpijob.yaml
@@ -12,7 +12,7 @@ spec:
       template:
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu22.04-nccl2.30.4-1-2eedd7c
+            - image: ghcr.io/coreweave/nccl-tests:13.3.0-devel-ubuntu24.04-nccl2.31.2-1-d08cf2b
               name: nccl
               env:
                 - name: OMPI_ALLOW_RUN_AS_ROOT
@@ -49,7 +49,7 @@ spec:
             metadata.coreweave.cloud/job: nccl-test
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu22.04-nccl2.30.4-1-2eedd7c
+            - image: ghcr.io/coreweave/nccl-tests:13.3.0-devel-ubuntu24.04-nccl2.31.2-1-d08cf2b
               name: nccl
               resources:
                 requests:

--- a/mpi-operator/nccl-test-distributed-b300-64-sharp-mpijob.yaml
+++ b/mpi-operator/nccl-test-distributed-b300-64-sharp-mpijob.yaml
@@ -12,7 +12,7 @@ spec:
       template:
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:13.3.0-devel-ubuntu24.04-nccl2.31.2-1-d08cf2b
+            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.31.2-1-ee0d4d1
               name: nccl
               env:
                 - name: OMPI_ALLOW_RUN_AS_ROOT
@@ -49,7 +49,7 @@ spec:
             metadata.coreweave.cloud/job: nccl-test
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:13.3.0-devel-ubuntu24.04-nccl2.31.2-1-d08cf2b
+            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.31.2-1-ee0d4d1
               name: nccl
               resources:
                 requests:

--- a/mpi-operator/nccl-test-distributed-b300-64-sharp-mpijob.yaml
+++ b/mpi-operator/nccl-test-distributed-b300-64-sharp-mpijob.yaml
@@ -12,7 +12,7 @@ spec:
       template:
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu22.04-nccl2.30.4-1-2eedd7c
+            - image: ghcr.io/coreweave/nccl-tests:13.3.0-devel-ubuntu24.04-nccl2.31.2-1-d08cf2b
               name: nccl
               env:
                 - name: OMPI_ALLOW_RUN_AS_ROOT
@@ -49,7 +49,7 @@ spec:
             metadata.coreweave.cloud/job: nccl-test
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu22.04-nccl2.30.4-1-2eedd7c
+            - image: ghcr.io/coreweave/nccl-tests:13.3.0-devel-ubuntu24.04-nccl2.31.2-1-d08cf2b
               name: nccl
               resources:
                 requests:

--- a/mpi-operator/nccl-test-distributed-gb200-128-multirack-mpijob.yaml
+++ b/mpi-operator/nccl-test-distributed-gb200-128-multirack-mpijob.yaml
@@ -17,7 +17,7 @@ spec:
       template:
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:13.3.0-devel-ubuntu24.04-nccl2.31.2-1-d08cf2b
+            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.31.2-1-ee0d4d1
               name: nccl
               env:
                 - name: OMPI_ALLOW_RUN_AS_ROOT
@@ -70,7 +70,7 @@ spec:
                 matchLabels:
                   metadata.coreweave.cloud/job: nccl-test
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:13.3.0-devel-ubuntu24.04-nccl2.31.2-1-d08cf2b
+            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.31.2-1-ee0d4d1
               name: nccl
               resources:
                 requests:

--- a/mpi-operator/nccl-test-distributed-gb200-128-multirack-mpijob.yaml
+++ b/mpi-operator/nccl-test-distributed-gb200-128-multirack-mpijob.yaml
@@ -17,7 +17,7 @@ spec:
       template:
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu22.04-nccl2.30.4-1-2eedd7c
+            - image: ghcr.io/coreweave/nccl-tests:13.3.0-devel-ubuntu24.04-nccl2.31.2-1-d08cf2b
               name: nccl
               env:
                 - name: OMPI_ALLOW_RUN_AS_ROOT
@@ -70,7 +70,7 @@ spec:
                 matchLabels:
                   metadata.coreweave.cloud/job: nccl-test
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu22.04-nccl2.30.4-1-2eedd7c
+            - image: ghcr.io/coreweave/nccl-tests:13.3.0-devel-ubuntu24.04-nccl2.31.2-1-d08cf2b
               name: nccl
               resources:
                 requests:

--- a/mpi-operator/nccl-test-distributed-gb200-nvl72-mpijob.yaml
+++ b/mpi-operator/nccl-test-distributed-gb200-nvl72-mpijob.yaml
@@ -14,7 +14,7 @@ spec:
       template:
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu22.04-nccl2.30.4-1-2eedd7c
+            - image: ghcr.io/coreweave/nccl-tests:13.3.0-devel-ubuntu24.04-nccl2.31.2-1-d08cf2b
               name: nccl
               env:
                 - name: OMPI_ALLOW_RUN_AS_ROOT
@@ -55,7 +55,7 @@ spec:
             metadata.coreweave.cloud/job: nccl-test
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu22.04-nccl2.30.4-1-2eedd7c
+            - image: ghcr.io/coreweave/nccl-tests:13.3.0-devel-ubuntu24.04-nccl2.31.2-1-d08cf2b
               name: nccl
               resources:
                 requests:

--- a/mpi-operator/nccl-test-distributed-gb200-nvl72-mpijob.yaml
+++ b/mpi-operator/nccl-test-distributed-gb200-nvl72-mpijob.yaml
@@ -14,7 +14,7 @@ spec:
       template:
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:13.3.0-devel-ubuntu24.04-nccl2.31.2-1-d08cf2b
+            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.31.2-1-ee0d4d1
               name: nccl
               env:
                 - name: OMPI_ALLOW_RUN_AS_ROOT
@@ -55,7 +55,7 @@ spec:
             metadata.coreweave.cloud/job: nccl-test
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:13.3.0-devel-ubuntu24.04-nccl2.31.2-1-d08cf2b
+            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.31.2-1-ee0d4d1
               name: nccl
               resources:
                 requests:

--- a/mpi-operator/nccl-test-distributed-gb300-nvl72-mpijob.yaml
+++ b/mpi-operator/nccl-test-distributed-gb300-nvl72-mpijob.yaml
@@ -16,7 +16,7 @@ spec:
       template:
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:13.3.0-devel-ubuntu24.04-nccl2.31.2-1-d08cf2b
+            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.31.2-1-ee0d4d1
               name: nccl
               env:
                 - name: OMPI_ALLOW_RUN_AS_ROOT
@@ -57,7 +57,7 @@ spec:
             metadata.coreweave.cloud/job: nccl-test
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:13.3.0-devel-ubuntu24.04-nccl2.31.2-1-d08cf2b
+            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.31.2-1-ee0d4d1
               name: nccl
               resources:
                 requests:

--- a/mpi-operator/nccl-test-distributed-gb300-nvl72-mpijob.yaml
+++ b/mpi-operator/nccl-test-distributed-gb300-nvl72-mpijob.yaml
@@ -16,7 +16,7 @@ spec:
       template:
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu22.04-nccl2.30.4-1-2eedd7c
+            - image: ghcr.io/coreweave/nccl-tests:13.3.0-devel-ubuntu24.04-nccl2.31.2-1-d08cf2b
               name: nccl
               env:
                 - name: OMPI_ALLOW_RUN_AS_ROOT
@@ -57,7 +57,7 @@ spec:
             metadata.coreweave.cloud/job: nccl-test
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu22.04-nccl2.30.4-1-2eedd7c
+            - image: ghcr.io/coreweave/nccl-tests:13.3.0-devel-ubuntu24.04-nccl2.31.2-1-d08cf2b
               name: nccl
               resources:
                 requests:

--- a/mpi-operator/nccl-test-distributed-gb300-roce-128-multirack-mpijob-dra.yaml
+++ b/mpi-operator/nccl-test-distributed-gb300-roce-128-multirack-mpijob-dra.yaml
@@ -35,7 +35,7 @@ spec:
       template:
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:13.3.0-devel-ubuntu24.04-nccl2.31.2-1-d08cf2b
+            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.31.2-1-ee0d4d1
               name: nccl
               env:
                 - name: OMPI_ALLOW_RUN_AS_ROOT
@@ -145,7 +145,7 @@ spec:
                 matchLabels:
                   metadata.coreweave.cloud/job: nccl-test
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:13.3.0-devel-ubuntu24.04-nccl2.31.2-1-d08cf2b
+            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.31.2-1-ee0d4d1
               name: nccl
               resources:
                 requests:

--- a/mpi-operator/nccl-test-distributed-gb300-roce-128-multirack-mpijob-dra.yaml
+++ b/mpi-operator/nccl-test-distributed-gb300-roce-128-multirack-mpijob-dra.yaml
@@ -35,7 +35,7 @@ spec:
       template:
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu22.04-nccl2.30.4-1-2eedd7c
+            - image: ghcr.io/coreweave/nccl-tests:13.3.0-devel-ubuntu24.04-nccl2.31.2-1-d08cf2b
               name: nccl
               env:
                 - name: OMPI_ALLOW_RUN_AS_ROOT
@@ -45,14 +45,14 @@ spec:
               # Uncomment to be able to exec in to launcher pod for interactive testing
               # command: [ 'sleep', '86400' ]
               command: ["/bin/bash", "-c"]
-              # NCCL_NET_PLUGIN: set to "spcx" for very large jobs (10k+ GPUs),
-              # "none" provides better performance for smaller jobs.
+              # NCCL_NET_PLUGIN: "spcx" enables the Spectrum-X NCCL plugin on RoCE;
+              # set to "none" to disable the plugin.
               # https://docs.nvidia.com/networking/display/hpcvx225/spectrum-x-nccl-plugin
               args: [
                   "mpirun \
                   -bind-to none \
                   -x LD_LIBRARY_PATH=/opt/hpcx/nccl_spectrum-x_plugin/lib:$LD_LIBRARY_PATH \
-                  -x NCCL_NET_PLUGIN=none \
+                  -x NCCL_NET_PLUGIN=spcx \
                   -x NCCL_IB_NET_LATENCY=50 \
                   -x NCCL_IB_ADAPTIVE_ROUTING=1 \
                   -x NCCL_NVLS_NCHANNELS=24 \
@@ -145,7 +145,7 @@ spec:
                 matchLabels:
                   metadata.coreweave.cloud/job: nccl-test
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu22.04-nccl2.30.4-1-2eedd7c
+            - image: ghcr.io/coreweave/nccl-tests:13.3.0-devel-ubuntu24.04-nccl2.31.2-1-d08cf2b
               name: nccl
               resources:
                 requests:

--- a/mpi-operator/nccl-test-distributed-gb300-roce-128-multirack-mpijob.yaml
+++ b/mpi-operator/nccl-test-distributed-gb300-roce-128-multirack-mpijob.yaml
@@ -18,7 +18,7 @@ spec:
       template:
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu22.04-nccl2.30.4-1-2eedd7c
+            - image: ghcr.io/coreweave/nccl-tests:13.3.0-devel-ubuntu24.04-nccl2.31.2-1-d08cf2b
               name: nccl
               env:
                 - name: OMPI_ALLOW_RUN_AS_ROOT
@@ -28,14 +28,14 @@ spec:
               # Uncomment to be able to exec in to launcher pod for interactive testing
               # command: [ 'sleep', '86400' ]
               command: ["/bin/bash", "-c"]
-              # NCCL_NET_PLUGIN: set to "spcx" for very large jobs (10k+ GPUs),
-              # "none" provides better performance for smaller jobs.
+              # NCCL_NET_PLUGIN: "spcx" enables the Spectrum-X NCCL plugin on RoCE;
+              # set to "none" to disable the plugin.
               # https://docs.nvidia.com/networking/display/hpcvx225/spectrum-x-nccl-plugin
               args: [
                   "mpirun \
                   -bind-to none \
                   -x LD_LIBRARY_PATH=/opt/hpcx/nccl_spectrum-x_plugin/lib:$LD_LIBRARY_PATH \
-                  -x NCCL_NET_PLUGIN=none \
+                  -x NCCL_NET_PLUGIN=spcx \
                   -x NCCL_IB_NET_LATENCY=50 \
                   -x NCCL_IB_ADAPTIVE_ROUTING=1 \
                   -x NCCL_NVLS_NCHANNELS=24 \
@@ -128,7 +128,7 @@ spec:
                 matchLabels:
                   metadata.coreweave.cloud/job: nccl-test
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu22.04-nccl2.30.4-1-2eedd7c
+            - image: ghcr.io/coreweave/nccl-tests:13.3.0-devel-ubuntu24.04-nccl2.31.2-1-d08cf2b
               name: nccl
               resources:
                 requests:

--- a/mpi-operator/nccl-test-distributed-gb300-roce-128-multirack-mpijob.yaml
+++ b/mpi-operator/nccl-test-distributed-gb300-roce-128-multirack-mpijob.yaml
@@ -18,7 +18,7 @@ spec:
       template:
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:13.3.0-devel-ubuntu24.04-nccl2.31.2-1-d08cf2b
+            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.31.2-1-ee0d4d1
               name: nccl
               env:
                 - name: OMPI_ALLOW_RUN_AS_ROOT
@@ -128,7 +128,7 @@ spec:
                 matchLabels:
                   metadata.coreweave.cloud/job: nccl-test
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:13.3.0-devel-ubuntu24.04-nccl2.31.2-1-d08cf2b
+            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.31.2-1-ee0d4d1
               name: nccl
               resources:
                 requests:

--- a/mpi-operator/nccl-test-distributed-gb300-roce-nvl72-mpijob-dra.yaml
+++ b/mpi-operator/nccl-test-distributed-gb300-roce-nvl72-mpijob-dra.yaml
@@ -32,7 +32,7 @@ spec:
       template:
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:13.3.0-devel-ubuntu24.04-nccl2.31.2-1-d08cf2b
+            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.31.2-1-ee0d4d1
               name: nccl
               env:
                 - name: OMPI_ALLOW_RUN_AS_ROOT
@@ -130,7 +130,7 @@ spec:
               }]
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:13.3.0-devel-ubuntu24.04-nccl2.31.2-1-d08cf2b
+            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.31.2-1-ee0d4d1
               name: nccl
               resources:
                 requests:

--- a/mpi-operator/nccl-test-distributed-gb300-roce-nvl72-mpijob-dra.yaml
+++ b/mpi-operator/nccl-test-distributed-gb300-roce-nvl72-mpijob-dra.yaml
@@ -32,7 +32,7 @@ spec:
       template:
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu22.04-nccl2.30.4-1-2eedd7c
+            - image: ghcr.io/coreweave/nccl-tests:13.3.0-devel-ubuntu24.04-nccl2.31.2-1-d08cf2b
               name: nccl
               env:
                 - name: OMPI_ALLOW_RUN_AS_ROOT
@@ -42,14 +42,14 @@ spec:
               # Uncomment to be able to exec in to launcher pod for interactive testing
               # command: [ 'sleep', '86400' ]
               command: ["/bin/bash", "-c"]
-              # NCCL_NET_PLUGIN: set to "spcx" for very large jobs (10k+ GPUs),
-              # "none" provides better performance for smaller jobs.
+              # NCCL_NET_PLUGIN: "spcx" enables the Spectrum-X NCCL plugin on RoCE;
+              # set to "none" to disable the plugin.
               # https://docs.nvidia.com/networking/display/hpcvx225/spectrum-x-nccl-plugin
               args: [
                   "mpirun \
                   -bind-to none \
                   -x LD_LIBRARY_PATH=/opt/hpcx/nccl_spectrum-x_plugin/lib:$LD_LIBRARY_PATH \
-                  -x NCCL_NET_PLUGIN=none \
+                  -x NCCL_NET_PLUGIN=spcx \
                   -x NCCL_IB_NET_LATENCY=50 \
                   -x NCCL_IB_ADAPTIVE_ROUTING=1 \
                   -x NCCL_NVLS_NCHANNELS=24 \
@@ -130,7 +130,7 @@ spec:
               }]
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu22.04-nccl2.30.4-1-2eedd7c
+            - image: ghcr.io/coreweave/nccl-tests:13.3.0-devel-ubuntu24.04-nccl2.31.2-1-d08cf2b
               name: nccl
               resources:
                 requests:

--- a/mpi-operator/nccl-test-distributed-gb300-roce-nvl72-mpijob.yaml
+++ b/mpi-operator/nccl-test-distributed-gb300-roce-nvl72-mpijob.yaml
@@ -15,7 +15,7 @@ spec:
       template:
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:13.3.0-devel-ubuntu24.04-nccl2.31.2-1-d08cf2b
+            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.31.2-1-ee0d4d1
               name: nccl
               env:
                 - name: OMPI_ALLOW_RUN_AS_ROOT
@@ -113,7 +113,7 @@ spec:
               }]
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:13.3.0-devel-ubuntu24.04-nccl2.31.2-1-d08cf2b
+            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.31.2-1-ee0d4d1
               name: nccl
               resources:
                 requests:

--- a/mpi-operator/nccl-test-distributed-gb300-roce-nvl72-mpijob.yaml
+++ b/mpi-operator/nccl-test-distributed-gb300-roce-nvl72-mpijob.yaml
@@ -15,7 +15,7 @@ spec:
       template:
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu22.04-nccl2.30.4-1-2eedd7c
+            - image: ghcr.io/coreweave/nccl-tests:13.3.0-devel-ubuntu24.04-nccl2.31.2-1-d08cf2b
               name: nccl
               env:
                 - name: OMPI_ALLOW_RUN_AS_ROOT
@@ -25,14 +25,14 @@ spec:
               # Uncomment to be able to exec in to launcher pod for interactive testing
               # command: [ 'sleep', '86400' ]
               command: ["/bin/bash", "-c"]
-              # NCCL_NET_PLUGIN: set to "spcx" for very large jobs (10k+ GPUs),
-              # "none" provides better performance for smaller jobs.
+              # NCCL_NET_PLUGIN: "spcx" enables the Spectrum-X NCCL plugin on RoCE;
+              # set to "none" to disable the plugin.
               # https://docs.nvidia.com/networking/display/hpcvx225/spectrum-x-nccl-plugin
               args: [
                   "mpirun \
                   -bind-to none \
                   -x LD_LIBRARY_PATH=/opt/hpcx/nccl_spectrum-x_plugin/lib:$LD_LIBRARY_PATH \
-                  -x NCCL_NET_PLUGIN=none \
+                  -x NCCL_NET_PLUGIN=spcx \
                   -x NCCL_IB_NET_LATENCY=50 \
                   -x NCCL_IB_ADAPTIVE_ROUTING=1 \
                   -x NCCL_NVLS_NCHANNELS=24 \
@@ -113,7 +113,7 @@ spec:
               }]
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu22.04-nccl2.30.4-1-2eedd7c
+            - image: ghcr.io/coreweave/nccl-tests:13.3.0-devel-ubuntu24.04-nccl2.31.2-1-d08cf2b
               name: nccl
               resources:
                 requests:

--- a/mpi-operator/nccl-test-distributed-h100-64-mpijob.yaml
+++ b/mpi-operator/nccl-test-distributed-h100-64-mpijob.yaml
@@ -12,7 +12,7 @@ spec:
       template:
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:13.3.0-devel-ubuntu24.04-nccl2.31.2-1-d08cf2b
+            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.31.2-1-ee0d4d1
               name: nccl
               env:
                 - name: OMPI_ALLOW_RUN_AS_ROOT
@@ -49,7 +49,7 @@ spec:
             metadata.coreweave.cloud/job: nccl-test
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:13.3.0-devel-ubuntu24.04-nccl2.31.2-1-d08cf2b
+            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.31.2-1-ee0d4d1
               name: nccl
               resources:
                 requests:

--- a/mpi-operator/nccl-test-distributed-h100-64-mpijob.yaml
+++ b/mpi-operator/nccl-test-distributed-h100-64-mpijob.yaml
@@ -12,7 +12,7 @@ spec:
       template:
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu22.04-nccl2.30.4-1-2eedd7c
+            - image: ghcr.io/coreweave/nccl-tests:13.3.0-devel-ubuntu24.04-nccl2.31.2-1-d08cf2b
               name: nccl
               env:
                 - name: OMPI_ALLOW_RUN_AS_ROOT
@@ -49,7 +49,7 @@ spec:
             metadata.coreweave.cloud/job: nccl-test
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu22.04-nccl2.30.4-1-2eedd7c
+            - image: ghcr.io/coreweave/nccl-tests:13.3.0-devel-ubuntu24.04-nccl2.31.2-1-d08cf2b
               name: nccl
               resources:
                 requests:

--- a/mpi-operator/nccl-test-distributed-h100-64-sharp-mpijob.yaml
+++ b/mpi-operator/nccl-test-distributed-h100-64-sharp-mpijob.yaml
@@ -12,7 +12,7 @@ spec:
       template:
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:13.3.0-devel-ubuntu24.04-nccl2.31.2-1-d08cf2b
+            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.31.2-1-ee0d4d1
               name: nccl
               env:
                 - name: OMPI_ALLOW_RUN_AS_ROOT
@@ -49,7 +49,7 @@ spec:
             metadata.coreweave.cloud/job: nccl-test
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:13.3.0-devel-ubuntu24.04-nccl2.31.2-1-d08cf2b
+            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.31.2-1-ee0d4d1
               name: nccl
               resources:
                 requests:

--- a/mpi-operator/nccl-test-distributed-h100-64-sharp-mpijob.yaml
+++ b/mpi-operator/nccl-test-distributed-h100-64-sharp-mpijob.yaml
@@ -12,7 +12,7 @@ spec:
       template:
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu22.04-nccl2.30.4-1-2eedd7c
+            - image: ghcr.io/coreweave/nccl-tests:13.3.0-devel-ubuntu24.04-nccl2.31.2-1-d08cf2b
               name: nccl
               env:
                 - name: OMPI_ALLOW_RUN_AS_ROOT
@@ -49,7 +49,7 @@ spec:
             metadata.coreweave.cloud/job: nccl-test
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu22.04-nccl2.30.4-1-2eedd7c
+            - image: ghcr.io/coreweave/nccl-tests:13.3.0-devel-ubuntu24.04-nccl2.31.2-1-d08cf2b
               name: nccl
               resources:
                 requests:

--- a/mpi-operator/templates/nccl-test-distributed-8x8-ib.yaml
+++ b/mpi-operator/templates/nccl-test-distributed-8x8-ib.yaml
@@ -14,7 +14,7 @@ spec:
           serviceAccountName: hpc-verification-hpc-sa
           initContainers:
             - name: wait-for-workers
-              image: ghcr.io/coreweave/nccl-tests:13.3.0-devel-ubuntu24.04-nccl2.31.2-1-d08cf2b
+              image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.31.2-1-ee0d4d1
               env:
                 - name: WORKERS
                   value: "8"
@@ -37,7 +37,7 @@ spec:
               operator: Exists
               key: node.coreweave.cloud/reserved
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:13.3.0-devel-ubuntu24.04-nccl2.31.2-1-d08cf2b
+            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.31.2-1-ee0d4d1
               name: nccl
               env:
                 - name: OMPI_ALLOW_RUN_AS_ROOT
@@ -74,7 +74,7 @@ spec:
             "k8s.v1.cni.cncf.io/networks": "[{\n  \"name\": \"ibs0p0-macvlan\",\n  \"namespace\": \"cw-multus\"\n},{\n  \"name\": \"ibs0p1-macvlan\",\n  \"namespace\": \"cw-multus\"\n},{\n  \"name\": \"ibs0p2-macvlan\",\n  \"namespace\": \"cw-multus\"\n},{\n  \"name\": \"ibs0p3-macvlan\",\n  \"namespace\": \"cw-multus\"\n},{\n  \"name\": \"ibs1p0-macvlan\",\n  \"namespace\": \"cw-multus\"\n},{\n  \"name\": \"ibs1p1-macvlan\",\n  \"namespace\": \"cw-multus\"\n},{\n  \"name\": \"ibs1p2-macvlan\",\n  \"namespace\": \"cw-multus\"\n},{\n  \"name\": \"ibs1p3-macvlan\",\n  \"namespace\": \"cw-multus\"\n},{\n  \"name\": \"ibs2p0-macvlan\",\n  \"namespace\": \"cw-multus\"\n},{\n  \"name\": \"ibs2p1-macvlan\",\n  \"namespace\": \"cw-multus\"\n},{\n  \"name\": \"ibs2p2-macvlan\",\n  \"namespace\": \"cw-multus\"\n},{\n  \"name\": \"ibs2p3-macvlan\",\n  \"namespace\": \"cw-multus\"\n},{\n  \"name\": \"ibs3p0-macvlan\",\n  \"namespace\": \"cw-multus\"\n},{\n  \"name\": \"ibs3p1-macvlan\",\n  \"namespace\": \"cw-multus\"\n},{\n  \"name\": \"ibs3p2-macvlan\",\n  \"namespace\": \"cw-multus\"\n},{\n  \"name\": \"ibs3p3-macvlan\",\n  \"namespace\": \"cw-multus\"\n}]"
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:13.3.0-devel-ubuntu24.04-nccl2.31.2-1-d08cf2b
+            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.31.2-1-ee0d4d1
               name: nccl
               securityContext:
                 privileged: true

--- a/mpi-operator/templates/nccl-test-distributed-8x8-ib.yaml
+++ b/mpi-operator/templates/nccl-test-distributed-8x8-ib.yaml
@@ -14,7 +14,7 @@ spec:
           serviceAccountName: hpc-verification-hpc-sa
           initContainers:
             - name: wait-for-workers
-              image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.30.4-1-9de30a5
+              image: ghcr.io/coreweave/nccl-tests:13.3.0-devel-ubuntu24.04-nccl2.31.2-1-d08cf2b
               env:
                 - name: WORKERS
                   value: "8"
@@ -37,7 +37,7 @@ spec:
               operator: Exists
               key: node.coreweave.cloud/reserved
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.30.4-1-9de30a5
+            - image: ghcr.io/coreweave/nccl-tests:13.3.0-devel-ubuntu24.04-nccl2.31.2-1-d08cf2b
               name: nccl
               env:
                 - name: OMPI_ALLOW_RUN_AS_ROOT
@@ -74,7 +74,7 @@ spec:
             "k8s.v1.cni.cncf.io/networks": "[{\n  \"name\": \"ibs0p0-macvlan\",\n  \"namespace\": \"cw-multus\"\n},{\n  \"name\": \"ibs0p1-macvlan\",\n  \"namespace\": \"cw-multus\"\n},{\n  \"name\": \"ibs0p2-macvlan\",\n  \"namespace\": \"cw-multus\"\n},{\n  \"name\": \"ibs0p3-macvlan\",\n  \"namespace\": \"cw-multus\"\n},{\n  \"name\": \"ibs1p0-macvlan\",\n  \"namespace\": \"cw-multus\"\n},{\n  \"name\": \"ibs1p1-macvlan\",\n  \"namespace\": \"cw-multus\"\n},{\n  \"name\": \"ibs1p2-macvlan\",\n  \"namespace\": \"cw-multus\"\n},{\n  \"name\": \"ibs1p3-macvlan\",\n  \"namespace\": \"cw-multus\"\n},{\n  \"name\": \"ibs2p0-macvlan\",\n  \"namespace\": \"cw-multus\"\n},{\n  \"name\": \"ibs2p1-macvlan\",\n  \"namespace\": \"cw-multus\"\n},{\n  \"name\": \"ibs2p2-macvlan\",\n  \"namespace\": \"cw-multus\"\n},{\n  \"name\": \"ibs2p3-macvlan\",\n  \"namespace\": \"cw-multus\"\n},{\n  \"name\": \"ibs3p0-macvlan\",\n  \"namespace\": \"cw-multus\"\n},{\n  \"name\": \"ibs3p1-macvlan\",\n  \"namespace\": \"cw-multus\"\n},{\n  \"name\": \"ibs3p2-macvlan\",\n  \"namespace\": \"cw-multus\"\n},{\n  \"name\": \"ibs3p3-macvlan\",\n  \"namespace\": \"cw-multus\"\n}]"
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.30.4-1-9de30a5
+            - image: ghcr.io/coreweave/nccl-tests:13.3.0-devel-ubuntu24.04-nccl2.31.2-1-d08cf2b
               name: nccl
               securityContext:
                 privileged: true

--- a/slurm/nccl-test-distributed-a100-64-enroot.slurm
+++ b/slurm/nccl-test-distributed-a100-64-enroot.slurm
@@ -20,7 +20,7 @@ export NCCL_NET_PLUGIN=none
 # Define nccl version we will test
 # See https://github.com/coreweave/nccl-tests/pkgs/container/nccl-tests for available tags.
 
-nccl_version="13.2.1-devel-ubuntu22.04-nccl2.30.4-1-2eedd7c"
+nccl_version="13.3.0-devel-ubuntu24.04-nccl2.31.2-1-d08cf2b"
 
 # Create a directory to store container images. You can change this
 # or use an existing directory below.

--- a/slurm/nccl-test-distributed-a100-64-enroot.slurm
+++ b/slurm/nccl-test-distributed-a100-64-enroot.slurm
@@ -20,7 +20,7 @@ export NCCL_NET_PLUGIN=none
 # Define nccl version we will test
 # See https://github.com/coreweave/nccl-tests/pkgs/container/nccl-tests for available tags.
 
-nccl_version="13.3.0-devel-ubuntu24.04-nccl2.31.2-1-d08cf2b"
+nccl_version="13.2.1-devel-ubuntu24.04-nccl2.31.2-1-ee0d4d1"
 
 # Create a directory to store container images. You can change this
 # or use an existing directory below.

--- a/slurm/nccl-test-distributed-b200-64-enroot-sharp.slurm
+++ b/slurm/nccl-test-distributed-b200-64-enroot-sharp.slurm
@@ -34,7 +34,7 @@ export PMIX_MCA_gds='^ds12'
 # Define nccl version we will test
 # See https://github.com/coreweave/nccl-tests/pkgs/container/nccl-tests for available tags.
 
-nccl_version="13.2.1-devel-ubuntu22.04-nccl2.30.4-1-2eedd7c"
+nccl_version="13.3.0-devel-ubuntu24.04-nccl2.31.2-1-d08cf2b"
 
 # Create a directory to store container images. You can change this
 # or use an existing directory below.

--- a/slurm/nccl-test-distributed-b200-64-enroot-sharp.slurm
+++ b/slurm/nccl-test-distributed-b200-64-enroot-sharp.slurm
@@ -34,7 +34,7 @@ export PMIX_MCA_gds='^ds12'
 # Define nccl version we will test
 # See https://github.com/coreweave/nccl-tests/pkgs/container/nccl-tests for available tags.
 
-nccl_version="13.3.0-devel-ubuntu24.04-nccl2.31.2-1-d08cf2b"
+nccl_version="13.2.1-devel-ubuntu24.04-nccl2.31.2-1-ee0d4d1"
 
 # Create a directory to store container images. You can change this
 # or use an existing directory below.

--- a/slurm/nccl-test-distributed-b200-64-enroot.slurm
+++ b/slurm/nccl-test-distributed-b200-64-enroot.slurm
@@ -31,7 +31,7 @@ export NCCL_NET_PLUGIN=none
 # Define nccl version we will test
 # See https://github.com/coreweave/nccl-tests/pkgs/container/nccl-tests for available tags.
 
-nccl_version="13.3.0-devel-ubuntu24.04-nccl2.31.2-1-d08cf2b"
+nccl_version="13.2.1-devel-ubuntu24.04-nccl2.31.2-1-ee0d4d1"
 
 # Create a directory to store container images. You can change this
 # or use an existing directory below.

--- a/slurm/nccl-test-distributed-b200-64-enroot.slurm
+++ b/slurm/nccl-test-distributed-b200-64-enroot.slurm
@@ -31,7 +31,7 @@ export NCCL_NET_PLUGIN=none
 # Define nccl version we will test
 # See https://github.com/coreweave/nccl-tests/pkgs/container/nccl-tests for available tags.
 
-nccl_version="13.2.1-devel-ubuntu22.04-nccl2.30.4-1-2eedd7c"
+nccl_version="13.3.0-devel-ubuntu24.04-nccl2.31.2-1-d08cf2b"
 
 # Create a directory to store container images. You can change this
 # or use an existing directory below.

--- a/slurm/nccl-test-distributed-b300-64-enroot-sharp.slurm
+++ b/slurm/nccl-test-distributed-b300-64-enroot-sharp.slurm
@@ -34,7 +34,7 @@ export PMIX_MCA_gds='^ds12'
 # Define nccl version we will test
 # See https://github.com/coreweave/nccl-tests/pkgs/container/nccl-tests for available tags.
 
-nccl_version="13.2.1-devel-ubuntu22.04-nccl2.30.4-1-2eedd7c"
+nccl_version="13.3.0-devel-ubuntu24.04-nccl2.31.2-1-d08cf2b"
 
 # Create a directory to store container images. You can change this
 # or use an existing directory below.

--- a/slurm/nccl-test-distributed-b300-64-enroot-sharp.slurm
+++ b/slurm/nccl-test-distributed-b300-64-enroot-sharp.slurm
@@ -34,7 +34,7 @@ export PMIX_MCA_gds='^ds12'
 # Define nccl version we will test
 # See https://github.com/coreweave/nccl-tests/pkgs/container/nccl-tests for available tags.
 
-nccl_version="13.3.0-devel-ubuntu24.04-nccl2.31.2-1-d08cf2b"
+nccl_version="13.2.1-devel-ubuntu24.04-nccl2.31.2-1-ee0d4d1"
 
 # Create a directory to store container images. You can change this
 # or use an existing directory below.

--- a/slurm/nccl-test-distributed-b300-64-enroot.slurm
+++ b/slurm/nccl-test-distributed-b300-64-enroot.slurm
@@ -31,7 +31,7 @@ export NCCL_NET_PLUGIN=none
 # Define nccl version we will test
 # See https://github.com/coreweave/nccl-tests/pkgs/container/nccl-tests for available tags.
 
-nccl_version="13.3.0-devel-ubuntu24.04-nccl2.31.2-1-d08cf2b"
+nccl_version="13.2.1-devel-ubuntu24.04-nccl2.31.2-1-ee0d4d1"
 
 # Create a directory to store container images. You can change this
 # or use an existing directory below.

--- a/slurm/nccl-test-distributed-b300-64-enroot.slurm
+++ b/slurm/nccl-test-distributed-b300-64-enroot.slurm
@@ -31,7 +31,7 @@ export NCCL_NET_PLUGIN=none
 # Define nccl version we will test
 # See https://github.com/coreweave/nccl-tests/pkgs/container/nccl-tests for available tags.
 
-nccl_version="13.2.1-devel-ubuntu22.04-nccl2.30.4-1-2eedd7c"
+nccl_version="13.3.0-devel-ubuntu24.04-nccl2.31.2-1-d08cf2b"
 
 # Create a directory to store container images. You can change this
 # or use an existing directory below.

--- a/slurm/nccl-test-distributed-gb200-nvl72-enroot.slurm
+++ b/slurm/nccl-test-distributed-gb200-nvl72-enroot.slurm
@@ -42,7 +42,7 @@ export NCCL_NET_PLUGIN=none
 # Define nccl version we will test
 # See https://github.com/coreweave/nccl-tests/pkgs/container/nccl-tests for available tags.
 
-nccl_version="13.3.0-devel-ubuntu24.04-nccl2.31.2-1-d08cf2b"
+nccl_version="13.2.1-devel-ubuntu24.04-nccl2.31.2-1-ee0d4d1"
 
 # Create a directory to store container images. You can change this
 # or use an existing directory below.

--- a/slurm/nccl-test-distributed-gb200-nvl72-enroot.slurm
+++ b/slurm/nccl-test-distributed-gb200-nvl72-enroot.slurm
@@ -42,7 +42,7 @@ export NCCL_NET_PLUGIN=none
 # Define nccl version we will test
 # See https://github.com/coreweave/nccl-tests/pkgs/container/nccl-tests for available tags.
 
-nccl_version="13.2.1-devel-ubuntu22.04-nccl2.30.4-1-2eedd7c"
+nccl_version="13.3.0-devel-ubuntu24.04-nccl2.31.2-1-d08cf2b"
 
 # Create a directory to store container images. You can change this
 # or use an existing directory below.

--- a/slurm/nccl-test-distributed-gb300-nvl72-enroot.slurm
+++ b/slurm/nccl-test-distributed-gb300-nvl72-enroot.slurm
@@ -44,7 +44,7 @@ export NCCL_NET_PLUGIN=none
 # Define nccl version we will test
 # See https://github.com/coreweave/nccl-tests/pkgs/container/nccl-tests for available tags.
 
-nccl_version="13.2.1-devel-ubuntu22.04-nccl2.30.4-1-2eedd7c"
+nccl_version="13.3.0-devel-ubuntu24.04-nccl2.31.2-1-d08cf2b"
 
 # Create a directory to store container images. You can change this
 # or use an existing directory below.

--- a/slurm/nccl-test-distributed-gb300-nvl72-enroot.slurm
+++ b/slurm/nccl-test-distributed-gb300-nvl72-enroot.slurm
@@ -44,7 +44,7 @@ export NCCL_NET_PLUGIN=none
 # Define nccl version we will test
 # See https://github.com/coreweave/nccl-tests/pkgs/container/nccl-tests for available tags.
 
-nccl_version="13.3.0-devel-ubuntu24.04-nccl2.31.2-1-d08cf2b"
+nccl_version="13.2.1-devel-ubuntu24.04-nccl2.31.2-1-ee0d4d1"
 
 # Create a directory to store container images. You can change this
 # or use an existing directory below.

--- a/slurm/nccl-test-distributed-gb300-roce-nvl72-enroot.slurm
+++ b/slurm/nccl-test-distributed-gb300-roce-nvl72-enroot.slurm
@@ -18,10 +18,9 @@
 
 # Spectrum-X NCCL plugin
 # https://docs.nvidia.com/networking/display/hpcvx225/spectrum-x-nccl-plugin
-# Set to "spcx" for very large jobs (10k+ GPUs) where the plugin can improve performance.
-# For smaller jobs, "none" provides better performance.
+# "spcx" enables the Spectrum-X NCCL plugin on RoCE; set to "none" to disable it.
 export LD_LIBRARY_PATH=/opt/hpcx/nccl_spectrum-x_plugin/lib:$LD_LIBRARY_PATH
-export NCCL_NET_PLUGIN=none
+export NCCL_NET_PLUGIN=spcx
 
 # RoCE / Spectrum-X tuning
 export NCCL_IB_NET_LATENCY=50
@@ -50,7 +49,7 @@ export PMIX_MCA_gds='^ds12'
 # Define nccl version we will test
 # See https://github.com/coreweave/nccl-tests/pkgs/container/nccl-tests for available tags.
 
-nccl_version="13.2.1-devel-ubuntu22.04-nccl2.30.4-1-2eedd7c"
+nccl_version="13.3.0-devel-ubuntu24.04-nccl2.31.2-1-d08cf2b"
 
 # Create a directory to store container images. You can change this
 # or use an existing directory below.

--- a/slurm/nccl-test-distributed-gb300-roce-nvl72-enroot.slurm
+++ b/slurm/nccl-test-distributed-gb300-roce-nvl72-enroot.slurm
@@ -49,7 +49,7 @@ export PMIX_MCA_gds='^ds12'
 # Define nccl version we will test
 # See https://github.com/coreweave/nccl-tests/pkgs/container/nccl-tests for available tags.
 
-nccl_version="13.3.0-devel-ubuntu24.04-nccl2.31.2-1-d08cf2b"
+nccl_version="13.2.1-devel-ubuntu24.04-nccl2.31.2-1-ee0d4d1"
 
 # Create a directory to store container images. You can change this
 # or use an existing directory below.

--- a/slurm/nccl-test-distributed-h100-64-enroot-sharp.slurm
+++ b/slurm/nccl-test-distributed-h100-64-enroot-sharp.slurm
@@ -34,7 +34,7 @@ export PMIX_MCA_gds='^ds12'
 # Define nccl version we will test
 # See https://github.com/coreweave/nccl-tests/pkgs/container/nccl-tests for available tags.
 
-nccl_version="13.2.1-devel-ubuntu22.04-nccl2.30.4-1-2eedd7c"
+nccl_version="13.3.0-devel-ubuntu24.04-nccl2.31.2-1-d08cf2b"
 
 # Create a directory to store container images. You can change this
 # or use an existing directory below.

--- a/slurm/nccl-test-distributed-h100-64-enroot-sharp.slurm
+++ b/slurm/nccl-test-distributed-h100-64-enroot-sharp.slurm
@@ -34,7 +34,7 @@ export PMIX_MCA_gds='^ds12'
 # Define nccl version we will test
 # See https://github.com/coreweave/nccl-tests/pkgs/container/nccl-tests for available tags.
 
-nccl_version="13.3.0-devel-ubuntu24.04-nccl2.31.2-1-d08cf2b"
+nccl_version="13.2.1-devel-ubuntu24.04-nccl2.31.2-1-ee0d4d1"
 
 # Create a directory to store container images. You can change this
 # or use an existing directory below.

--- a/slurm/nccl-test-distributed-h100-64-enroot.slurm
+++ b/slurm/nccl-test-distributed-h100-64-enroot.slurm
@@ -31,7 +31,7 @@ export NCCL_NET_PLUGIN=none
 # Define nccl version we will test
 # See https://github.com/coreweave/nccl-tests/pkgs/container/nccl-tests for available tags.
 
-nccl_version="13.3.0-devel-ubuntu24.04-nccl2.31.2-1-d08cf2b"
+nccl_version="13.2.1-devel-ubuntu24.04-nccl2.31.2-1-ee0d4d1"
 
 # Create a directory to store container images. You can change this
 # or use an existing directory below.

--- a/slurm/nccl-test-distributed-h100-64-enroot.slurm
+++ b/slurm/nccl-test-distributed-h100-64-enroot.slurm
@@ -31,7 +31,7 @@ export NCCL_NET_PLUGIN=none
 # Define nccl version we will test
 # See https://github.com/coreweave/nccl-tests/pkgs/container/nccl-tests for available tags.
 
-nccl_version="13.2.1-devel-ubuntu22.04-nccl2.30.4-1-2eedd7c"
+nccl_version="13.3.0-devel-ubuntu24.04-nccl2.31.2-1-d08cf2b"
 
 # Create a directory to store container images. You can change this
 # or use an existing directory below.


### PR DESCRIPTION
This PR updates our MPI and Slurm sample scripts + READMEs to use latest NCCL container and to enable SPCX on RoCE now that said container contains HPC-X v2.50 which improves performance.