### PR TITLE
feat: Swap default NCCL net plugin to `nccl_spectrum-x_plugin`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -186,9 +186,7 @@ RUN source /opt/hpcx/hpcx-init.sh && \
 SHELL ["/bin/sh", "-c"]
 
 
-# This stage is mostly shared between amd64 and arm64,
-# but arm64 has a few extra steps appended to it later
-FROM base AS base-amd64
+FROM base
 RUN --mount=type=bind,from=libnccl2,source=/tmp/libnccl2,target=/tmp/install \
     cd /tmp/install && dpkg -i *.deb
 RUN --mount=type=bind,from=gdrcopy,source=/tmp/gdrcopy,target=/tmp/install \
@@ -255,25 +253,19 @@ ENV OSHMEM_HOME=/opt/hpcx/ompi
 ENV OPAL_PREFIX=/opt/hpcx/ompi
 ENV OLD_PATH=/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 ENV PATH=/opt/hpcx/sharp/bin:/opt/hpcx/clusterkit/bin:/opt/hpcx/hcoll/bin:/opt/hpcx/ucc/bin:/opt/hpcx/ucx/bin:/opt/hpcx/ompi/bin:/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-ENV OLD_LD_LIBRARY_PATH=/usr/local/nvidia/lib:/usr/local/nvidia/lib64
-ENV LD_LIBRARY_PATH=/opt/hpcx/nccl_rdma_sharp_plugin/lib:/opt/hpcx/ucc/lib/ucc:/opt/hpcx/ucc/lib:/opt/hpcx/ucx/lib/ucx:/opt/hpcx/ucx/lib:/opt/hpcx/sharp/lib:/opt/hpcx/hcoll/lib:/opt/hpcx/ompi/lib:/usr/local/nvidia/lib:/usr/local/nvidia/lib64
+ENV OLD_LD_LIBRARY_PATH=/usr/local/nvidia/lib:/usr/local/nvidia/lib64:/usr/local/cuda/lib64
+ENV LD_LIBRARY_PATH=/opt/hpcx/nccl_spectrum-x_plugin/lib:/opt/hpcx/nccl_rdma_sharp_plugin/lib:/opt/hpcx/ucc/lib/ucc:/opt/hpcx/ucc/lib:/opt/hpcx/ucx/lib/ucx:/opt/hpcx/ucx/lib:/opt/hpcx/sharp/lib:/opt/hpcx/hcoll/lib:/opt/hpcx/ompi/lib:/usr/local/nvidia/lib:/usr/local/nvidia/lib64:/usr/local/cuda/lib64
 ENV OLD_LIBRARY_PATH=/usr/local/cuda/lib64/stubs
-ENV LIBRARY_PATH=/opt/hpcx/nccl_rdma_sharp_plugin/lib:/opt/hpcx/ompi/lib:/opt/hpcx/sharp/lib:/opt/hpcx/ucc/lib:/opt/hpcx/ucx/lib:/opt/hpcx/hcoll/lib:/opt/hpcx/ompi/lib:/usr/local/cuda/lib64/stubs
+ENV LIBRARY_PATH=/opt/hpcx/nccl_spectrum-x_plugin/lib:/opt/hpcx/nccl_rdma_sharp_plugin/lib:/opt/hpcx/sharp/lib:/opt/hpcx/ucc/lib:/opt/hpcx/ucx/lib:/opt/hpcx/hcoll/lib:/opt/hpcx/ompi/lib:/usr/local/cuda/lib64/stubs
 ENV OLD_CPATH=""
 ENV CPATH=/opt/hpcx/ompi/include:/opt/hpcx/ucc/include:/opt/hpcx/ucx/include:/opt/hpcx/sharp/include:/opt/hpcx/hcoll/include
 ENV PKG_CONFIG_PATH=/opt/hpcx/hcoll/lib/pkgconfig:/opt/hpcx/sharp/lib/pkgconfig:/opt/hpcx/ucx/lib/pkgconfig:/opt/hpcx/ompi/lib/pkgconfig
 # End of auto-generated paths
 
-FROM base-amd64 AS base-arm64
-# Clusterkit isn't included in HPC-X on ARM64 (as of v2.22)
-ENV HPCX_CLUSTERKIT_DIR=""
-ENV PATH=/opt/hpcx/sharp/bin/bin:/opt/hpcx/hcoll/bin:/opt/hpcx/ucc/bin:/opt/hpcx/ucx/bin:/opt/hpcx/ompi/bin:/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-
-FROM base-${TARGETARCH}
 # Disable UCX VFS to stop errors about fuse mount failure
 ENV UCX_VFS_ENABLE=no
 
-# NCCL SHARP PLugin (master)
+# NCCL SHARP Plugin (master)
 ### Disabled as HPC-X has a recent enough version at this time
 # RUN cd /tmp && \
 #     wget -q https://github.com/Mellanox/nccl-rdma-sharp-plugins/archive/refs/heads/master.zip && \

--- a/README.md
+++ b/README.md
@@ -73,23 +73,23 @@ Compute capabilities up to Blackwell (10.0 & 12.0) are supported.
 
 | **Image Tag**                                                              | **CUDA** |
 |----------------------------------------------------------------------------|----------|
-| ghcr.io/coreweave/nccl-tests:13.3.0-devel-ubuntu24.04-nccl2.31.2-1-ee0d4d1 | 13.3.0   |
-| ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.31.2-1-ee0d4d1 | 13.2.1   |
-| ghcr.io/coreweave/nccl-tests:13.1.2-devel-ubuntu24.04-nccl2.31.2-1-ee0d4d1 | 13.1.2   |
-| ghcr.io/coreweave/nccl-tests:13.0.3-devel-ubuntu24.04-nccl2.31.2-1-ee0d4d1 | 13.0.3   |
-| ghcr.io/coreweave/nccl-tests:12.9.2-devel-ubuntu24.04-nccl2.31.2-1-ee0d4d1 | 12.9.2   |
+| ghcr.io/coreweave/nccl-tests:13.3.0-devel-ubuntu24.04-nccl2.31.2-1-478d8e5 | 13.3.0   |
+| ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.31.2-1-478d8e5 | 13.2.1   |
+| ghcr.io/coreweave/nccl-tests:13.1.2-devel-ubuntu24.04-nccl2.31.2-1-478d8e5 | 13.1.2   |
+| ghcr.io/coreweave/nccl-tests:13.0.3-devel-ubuntu24.04-nccl2.31.2-1-478d8e5 | 13.0.3   |
+| ghcr.io/coreweave/nccl-tests:12.9.2-devel-ubuntu24.04-nccl2.31.2-1-478d8e5 | 12.9.2   |
 
 ### Ubuntu 22.04
 
 | **Image Tag**                                                              | **CUDA** |
 |----------------------------------------------------------------------------|----------|
-| ghcr.io/coreweave/nccl-tests:13.3.0-devel-ubuntu22.04-nccl2.31.2-1-ee0d4d1 | 13.3.0   |
-| ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu22.04-nccl2.31.2-1-ee0d4d1 | 13.2.1   |
-| ghcr.io/coreweave/nccl-tests:13.1.2-devel-ubuntu22.04-nccl2.31.2-1-ee0d4d1 | 13.1.2   |
-| ghcr.io/coreweave/nccl-tests:13.0.3-devel-ubuntu22.04-nccl2.31.2-1-ee0d4d1 | 13.0.3   |
-| ghcr.io/coreweave/nccl-tests:12.9.2-devel-ubuntu22.04-nccl2.31.2-1-ee0d4d1 | 12.9.2   |
-| ghcr.io/coreweave/nccl-tests:12.8.2-devel-ubuntu22.04-nccl2.31.2-1-ee0d4d1 | 12.8.2   |
-| ghcr.io/coreweave/nccl-tests:12.6.3-devel-ubuntu22.04-nccl2.31.2-1-ee0d4d1 | 12.6.3   |
+| ghcr.io/coreweave/nccl-tests:13.3.0-devel-ubuntu22.04-nccl2.31.2-1-478d8e5 | 13.3.0   |
+| ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu22.04-nccl2.31.2-1-478d8e5 | 13.2.1   |
+| ghcr.io/coreweave/nccl-tests:13.1.2-devel-ubuntu22.04-nccl2.31.2-1-478d8e5 | 13.1.2   |
+| ghcr.io/coreweave/nccl-tests:13.0.3-devel-ubuntu22.04-nccl2.31.2-1-478d8e5 | 13.0.3   |
+| ghcr.io/coreweave/nccl-tests:12.9.2-devel-ubuntu22.04-nccl2.31.2-1-478d8e5 | 12.9.2   |
+| ghcr.io/coreweave/nccl-tests:12.8.2-devel-ubuntu22.04-nccl2.31.2-1-478d8e5 | 12.8.2   |
+| ghcr.io/coreweave/nccl-tests:12.6.3-devel-ubuntu22.04-nccl2.31.2-1-478d8e5 | 12.6.3   |
 
 ## Running NCCL Tests
 

--- a/mpi-operator/nccl-test-distributed-a100-64-gdrcopy-mpijob.yaml
+++ b/mpi-operator/nccl-test-distributed-a100-64-gdrcopy-mpijob.yaml
@@ -12,7 +12,7 @@ spec:
       template:
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.31.2-1-ee0d4d1
+            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.31.2-1-478d8e5
               name: nccl
               env:
                 - name: OMPI_ALLOW_RUN_AS_ROOT
@@ -44,7 +44,7 @@ spec:
       template:
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.31.2-1-ee0d4d1
+            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.31.2-1-478d8e5
               name: nccl
               resources:
                 requests:

--- a/mpi-operator/nccl-test-distributed-a100-64-mpijob.yaml
+++ b/mpi-operator/nccl-test-distributed-a100-64-mpijob.yaml
@@ -12,7 +12,7 @@ spec:
       template:
           spec:
             containers:
-            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.31.2-1-ee0d4d1
+            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.31.2-1-478d8e5
               name: nccl
               env:
               - name: OMPI_ALLOW_RUN_AS_ROOT
@@ -45,7 +45,7 @@ spec:
             metadata.coreweave.cloud/job: nccl-test
         spec:
           containers:
-          - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.31.2-1-ee0d4d1
+          - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.31.2-1-478d8e5
             name: nccl
             resources:
               requests:

--- a/mpi-operator/nccl-test-distributed-a100-64-noib-mpijob.yaml
+++ b/mpi-operator/nccl-test-distributed-a100-64-noib-mpijob.yaml
@@ -12,7 +12,7 @@ spec:
       template:
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.31.2-1-ee0d4d1
+            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.31.2-1-478d8e5
               name: nccl
               env:
                 - name: OMPI_ALLOW_RUN_AS_ROOT
@@ -47,7 +47,7 @@ spec:
             metadata.coreweave.cloud/job: nccl-test
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.31.2-1-ee0d4d1
+            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.31.2-1-478d8e5
               name: nccl
               resources:
                 requests:

--- a/mpi-operator/nccl-test-distributed-a100-64-sharp-mpijob.yaml
+++ b/mpi-operator/nccl-test-distributed-a100-64-sharp-mpijob.yaml
@@ -12,7 +12,7 @@ spec:
       template:
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.31.2-1-ee0d4d1
+            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.31.2-1-478d8e5
               name: nccl
               env:
                 - name: OMPI_ALLOW_RUN_AS_ROOT
@@ -48,7 +48,7 @@ spec:
             metadata.coreweave.cloud/job: nccl-test
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.31.2-1-ee0d4d1
+            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.31.2-1-478d8e5
               name: nccl
               resources:
                 requests:

--- a/mpi-operator/nccl-test-distributed-a40-64-mpijob.yaml
+++ b/mpi-operator/nccl-test-distributed-a40-64-mpijob.yaml
@@ -12,7 +12,7 @@ spec:
       template:
           spec:
             containers:
-            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.31.2-1-ee0d4d1
+            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.31.2-1-478d8e5
               name: nccl
               env:
               - name: OMPI_ALLOW_RUN_AS_ROOT
@@ -42,7 +42,7 @@ spec:
       template:
         spec:
           containers:
-          - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.31.2-1-ee0d4d1
+          - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.31.2-1-478d8e5
             name: nccl
             resources:
               requests:

--- a/mpi-operator/nccl-test-distributed-b200-64-mpijob.yaml
+++ b/mpi-operator/nccl-test-distributed-b200-64-mpijob.yaml
@@ -12,7 +12,7 @@ spec:
       template:
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.31.2-1-ee0d4d1
+            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.31.2-1-478d8e5
               name: nccl
               env:
                 - name: OMPI_ALLOW_RUN_AS_ROOT
@@ -49,7 +49,7 @@ spec:
             metadata.coreweave.cloud/job: nccl-test
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.31.2-1-ee0d4d1
+            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.31.2-1-478d8e5
               name: nccl
               resources:
                 requests:

--- a/mpi-operator/nccl-test-distributed-b200-64-sharp-mpijob.yaml
+++ b/mpi-operator/nccl-test-distributed-b200-64-sharp-mpijob.yaml
@@ -12,7 +12,7 @@ spec:
       template:
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.31.2-1-ee0d4d1
+            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.31.2-1-478d8e5
               name: nccl
               env:
                 - name: OMPI_ALLOW_RUN_AS_ROOT
@@ -49,7 +49,7 @@ spec:
             metadata.coreweave.cloud/job: nccl-test
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.31.2-1-ee0d4d1
+            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.31.2-1-478d8e5
               name: nccl
               resources:
                 requests:

--- a/mpi-operator/nccl-test-distributed-b300-64-mpijob.yaml
+++ b/mpi-operator/nccl-test-distributed-b300-64-mpijob.yaml
@@ -12,7 +12,7 @@ spec:
       template:
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.31.2-1-ee0d4d1
+            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.31.2-1-478d8e5
               name: nccl
               env:
                 - name: OMPI_ALLOW_RUN_AS_ROOT
@@ -49,7 +49,7 @@ spec:
             metadata.coreweave.cloud/job: nccl-test
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.31.2-1-ee0d4d1
+            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.31.2-1-478d8e5
               name: nccl
               resources:
                 requests:

--- a/mpi-operator/nccl-test-distributed-b300-64-sharp-mpijob.yaml
+++ b/mpi-operator/nccl-test-distributed-b300-64-sharp-mpijob.yaml
@@ -12,7 +12,7 @@ spec:
       template:
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.31.2-1-ee0d4d1
+            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.31.2-1-478d8e5
               name: nccl
               env:
                 - name: OMPI_ALLOW_RUN_AS_ROOT
@@ -49,7 +49,7 @@ spec:
             metadata.coreweave.cloud/job: nccl-test
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.31.2-1-ee0d4d1
+            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.31.2-1-478d8e5
               name: nccl
               resources:
                 requests:

--- a/mpi-operator/nccl-test-distributed-gb200-128-multirack-mpijob.yaml
+++ b/mpi-operator/nccl-test-distributed-gb200-128-multirack-mpijob.yaml
@@ -17,7 +17,7 @@ spec:
       template:
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.31.2-1-ee0d4d1
+            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.31.2-1-478d8e5
               name: nccl
               env:
                 - name: OMPI_ALLOW_RUN_AS_ROOT
@@ -70,7 +70,7 @@ spec:
                 matchLabels:
                   metadata.coreweave.cloud/job: nccl-test
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.31.2-1-ee0d4d1
+            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.31.2-1-478d8e5
               name: nccl
               resources:
                 requests:

--- a/mpi-operator/nccl-test-distributed-gb200-nvl72-mpijob.yaml
+++ b/mpi-operator/nccl-test-distributed-gb200-nvl72-mpijob.yaml
@@ -14,7 +14,7 @@ spec:
       template:
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.31.2-1-ee0d4d1
+            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.31.2-1-478d8e5
               name: nccl
               env:
                 - name: OMPI_ALLOW_RUN_AS_ROOT
@@ -55,7 +55,7 @@ spec:
             metadata.coreweave.cloud/job: nccl-test
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.31.2-1-ee0d4d1
+            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.31.2-1-478d8e5
               name: nccl
               resources:
                 requests:

--- a/mpi-operator/nccl-test-distributed-gb300-nvl72-mpijob.yaml
+++ b/mpi-operator/nccl-test-distributed-gb300-nvl72-mpijob.yaml
@@ -16,7 +16,7 @@ spec:
       template:
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.31.2-1-ee0d4d1
+            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.31.2-1-478d8e5
               name: nccl
               env:
                 - name: OMPI_ALLOW_RUN_AS_ROOT
@@ -57,7 +57,7 @@ spec:
             metadata.coreweave.cloud/job: nccl-test
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.31.2-1-ee0d4d1
+            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.31.2-1-478d8e5
               name: nccl
               resources:
                 requests:

--- a/mpi-operator/nccl-test-distributed-gb300-roce-128-multirack-mpijob-dra.yaml
+++ b/mpi-operator/nccl-test-distributed-gb300-roce-128-multirack-mpijob-dra.yaml
@@ -35,7 +35,7 @@ spec:
       template:
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.31.2-1-ee0d4d1
+            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.31.2-1-478d8e5
               name: nccl
               env:
                 - name: OMPI_ALLOW_RUN_AS_ROOT
@@ -51,7 +51,6 @@ spec:
               args: [
                   "mpirun \
                   -bind-to none \
-                  -x LD_LIBRARY_PATH=/opt/hpcx/nccl_spectrum-x_plugin/lib:$LD_LIBRARY_PATH \
                   -x NCCL_NET_PLUGIN=spcx \
                   -x NCCL_IB_NET_LATENCY=50 \
                   -x NCCL_IB_ADAPTIVE_ROUTING=1 \
@@ -145,7 +144,7 @@ spec:
                 matchLabels:
                   metadata.coreweave.cloud/job: nccl-test
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.31.2-1-ee0d4d1
+            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.31.2-1-478d8e5
               name: nccl
               resources:
                 requests:

--- a/mpi-operator/nccl-test-distributed-gb300-roce-128-multirack-mpijob.yaml
+++ b/mpi-operator/nccl-test-distributed-gb300-roce-128-multirack-mpijob.yaml
@@ -18,7 +18,7 @@ spec:
       template:
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.31.2-1-ee0d4d1
+            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.31.2-1-478d8e5
               name: nccl
               env:
                 - name: OMPI_ALLOW_RUN_AS_ROOT
@@ -34,7 +34,6 @@ spec:
               args: [
                   "mpirun \
                   -bind-to none \
-                  -x LD_LIBRARY_PATH=/opt/hpcx/nccl_spectrum-x_plugin/lib:$LD_LIBRARY_PATH \
                   -x NCCL_NET_PLUGIN=spcx \
                   -x NCCL_IB_NET_LATENCY=50 \
                   -x NCCL_IB_ADAPTIVE_ROUTING=1 \
@@ -128,7 +127,7 @@ spec:
                 matchLabels:
                   metadata.coreweave.cloud/job: nccl-test
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.31.2-1-ee0d4d1
+            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.31.2-1-478d8e5
               name: nccl
               resources:
                 requests:

--- a/mpi-operator/nccl-test-distributed-gb300-roce-nvl72-mpijob-dra.yaml
+++ b/mpi-operator/nccl-test-distributed-gb300-roce-nvl72-mpijob-dra.yaml
@@ -32,7 +32,7 @@ spec:
       template:
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.31.2-1-ee0d4d1
+            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.31.2-1-478d8e5
               name: nccl
               env:
                 - name: OMPI_ALLOW_RUN_AS_ROOT
@@ -48,7 +48,6 @@ spec:
               args: [
                   "mpirun \
                   -bind-to none \
-                  -x LD_LIBRARY_PATH=/opt/hpcx/nccl_spectrum-x_plugin/lib:$LD_LIBRARY_PATH \
                   -x NCCL_NET_PLUGIN=spcx \
                   -x NCCL_IB_NET_LATENCY=50 \
                   -x NCCL_IB_ADAPTIVE_ROUTING=1 \
@@ -130,7 +129,7 @@ spec:
               }]
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.31.2-1-ee0d4d1
+            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.31.2-1-478d8e5
               name: nccl
               resources:
                 requests:

--- a/mpi-operator/nccl-test-distributed-gb300-roce-nvl72-mpijob.yaml
+++ b/mpi-operator/nccl-test-distributed-gb300-roce-nvl72-mpijob.yaml
@@ -15,7 +15,7 @@ spec:
       template:
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.31.2-1-ee0d4d1
+            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.31.2-1-478d8e5
               name: nccl
               env:
                 - name: OMPI_ALLOW_RUN_AS_ROOT
@@ -31,7 +31,6 @@ spec:
               args: [
                   "mpirun \
                   -bind-to none \
-                  -x LD_LIBRARY_PATH=/opt/hpcx/nccl_spectrum-x_plugin/lib:$LD_LIBRARY_PATH \
                   -x NCCL_NET_PLUGIN=spcx \
                   -x NCCL_IB_NET_LATENCY=50 \
                   -x NCCL_IB_ADAPTIVE_ROUTING=1 \
@@ -113,7 +112,7 @@ spec:
               }]
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.31.2-1-ee0d4d1
+            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.31.2-1-478d8e5
               name: nccl
               resources:
                 requests:

--- a/mpi-operator/nccl-test-distributed-h100-64-mpijob.yaml
+++ b/mpi-operator/nccl-test-distributed-h100-64-mpijob.yaml
@@ -12,7 +12,7 @@ spec:
       template:
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.31.2-1-ee0d4d1
+            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.31.2-1-478d8e5
               name: nccl
               env:
                 - name: OMPI_ALLOW_RUN_AS_ROOT
@@ -49,7 +49,7 @@ spec:
             metadata.coreweave.cloud/job: nccl-test
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.31.2-1-ee0d4d1
+            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.31.2-1-478d8e5
               name: nccl
               resources:
                 requests:

--- a/mpi-operator/nccl-test-distributed-h100-64-sharp-mpijob.yaml
+++ b/mpi-operator/nccl-test-distributed-h100-64-sharp-mpijob.yaml
@@ -12,7 +12,7 @@ spec:
       template:
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.31.2-1-ee0d4d1
+            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.31.2-1-478d8e5
               name: nccl
               env:
                 - name: OMPI_ALLOW_RUN_AS_ROOT
@@ -49,7 +49,7 @@ spec:
             metadata.coreweave.cloud/job: nccl-test
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.31.2-1-ee0d4d1
+            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.31.2-1-478d8e5
               name: nccl
               resources:
                 requests:

--- a/mpi-operator/templates/nccl-test-distributed-8x8-ib.yaml
+++ b/mpi-operator/templates/nccl-test-distributed-8x8-ib.yaml
@@ -14,7 +14,7 @@ spec:
           serviceAccountName: hpc-verification-hpc-sa
           initContainers:
             - name: wait-for-workers
-              image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.31.2-1-ee0d4d1
+              image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.31.2-1-478d8e5
               env:
                 - name: WORKERS
                   value: "8"
@@ -37,7 +37,7 @@ spec:
               operator: Exists
               key: node.coreweave.cloud/reserved
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.31.2-1-ee0d4d1
+            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.31.2-1-478d8e5
               name: nccl
               env:
                 - name: OMPI_ALLOW_RUN_AS_ROOT
@@ -74,7 +74,7 @@ spec:
             "k8s.v1.cni.cncf.io/networks": "[{\n  \"name\": \"ibs0p0-macvlan\",\n  \"namespace\": \"cw-multus\"\n},{\n  \"name\": \"ibs0p1-macvlan\",\n  \"namespace\": \"cw-multus\"\n},{\n  \"name\": \"ibs0p2-macvlan\",\n  \"namespace\": \"cw-multus\"\n},{\n  \"name\": \"ibs0p3-macvlan\",\n  \"namespace\": \"cw-multus\"\n},{\n  \"name\": \"ibs1p0-macvlan\",\n  \"namespace\": \"cw-multus\"\n},{\n  \"name\": \"ibs1p1-macvlan\",\n  \"namespace\": \"cw-multus\"\n},{\n  \"name\": \"ibs1p2-macvlan\",\n  \"namespace\": \"cw-multus\"\n},{\n  \"name\": \"ibs1p3-macvlan\",\n  \"namespace\": \"cw-multus\"\n},{\n  \"name\": \"ibs2p0-macvlan\",\n  \"namespace\": \"cw-multus\"\n},{\n  \"name\": \"ibs2p1-macvlan\",\n  \"namespace\": \"cw-multus\"\n},{\n  \"name\": \"ibs2p2-macvlan\",\n  \"namespace\": \"cw-multus\"\n},{\n  \"name\": \"ibs2p3-macvlan\",\n  \"namespace\": \"cw-multus\"\n},{\n  \"name\": \"ibs3p0-macvlan\",\n  \"namespace\": \"cw-multus\"\n},{\n  \"name\": \"ibs3p1-macvlan\",\n  \"namespace\": \"cw-multus\"\n},{\n  \"name\": \"ibs3p2-macvlan\",\n  \"namespace\": \"cw-multus\"\n},{\n  \"name\": \"ibs3p3-macvlan\",\n  \"namespace\": \"cw-multus\"\n}]"
         spec:
           containers:
-            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.31.2-1-ee0d4d1
+            - image: ghcr.io/coreweave/nccl-tests:13.2.1-devel-ubuntu24.04-nccl2.31.2-1-478d8e5
               name: nccl
               securityContext:
                 privileged: true

--- a/slurm/nccl-test-distributed-a100-64-enroot.slurm
+++ b/slurm/nccl-test-distributed-a100-64-enroot.slurm
@@ -20,7 +20,7 @@ export NCCL_NET_PLUGIN=none
 # Define nccl version we will test
 # See https://github.com/coreweave/nccl-tests/pkgs/container/nccl-tests for available tags.
 
-nccl_version="13.2.1-devel-ubuntu24.04-nccl2.31.2-1-ee0d4d1"
+nccl_version="13.2.1-devel-ubuntu24.04-nccl2.31.2-1-478d8e5"
 
 # Create a directory to store container images. You can change this
 # or use an existing directory below.

--- a/slurm/nccl-test-distributed-b200-64-enroot-sharp.slurm
+++ b/slurm/nccl-test-distributed-b200-64-enroot-sharp.slurm
@@ -34,7 +34,7 @@ export PMIX_MCA_gds='^ds12'
 # Define nccl version we will test
 # See https://github.com/coreweave/nccl-tests/pkgs/container/nccl-tests for available tags.
 
-nccl_version="13.2.1-devel-ubuntu24.04-nccl2.31.2-1-ee0d4d1"
+nccl_version="13.2.1-devel-ubuntu24.04-nccl2.31.2-1-478d8e5"
 
 # Create a directory to store container images. You can change this
 # or use an existing directory below.

--- a/slurm/nccl-test-distributed-b200-64-enroot.slurm
+++ b/slurm/nccl-test-distributed-b200-64-enroot.slurm
@@ -31,7 +31,7 @@ export NCCL_NET_PLUGIN=none
 # Define nccl version we will test
 # See https://github.com/coreweave/nccl-tests/pkgs/container/nccl-tests for available tags.
 
-nccl_version="13.2.1-devel-ubuntu24.04-nccl2.31.2-1-ee0d4d1"
+nccl_version="13.2.1-devel-ubuntu24.04-nccl2.31.2-1-478d8e5"
 
 # Create a directory to store container images. You can change this
 # or use an existing directory below.

--- a/slurm/nccl-test-distributed-b300-64-enroot-sharp.slurm
+++ b/slurm/nccl-test-distributed-b300-64-enroot-sharp.slurm
@@ -34,7 +34,7 @@ export PMIX_MCA_gds='^ds12'
 # Define nccl version we will test
 # See https://github.com/coreweave/nccl-tests/pkgs/container/nccl-tests for available tags.
 
-nccl_version="13.2.1-devel-ubuntu24.04-nccl2.31.2-1-ee0d4d1"
+nccl_version="13.2.1-devel-ubuntu24.04-nccl2.31.2-1-478d8e5"
 
 # Create a directory to store container images. You can change this
 # or use an existing directory below.

--- a/slurm/nccl-test-distributed-b300-64-enroot.slurm
+++ b/slurm/nccl-test-distributed-b300-64-enroot.slurm
@@ -31,7 +31,7 @@ export NCCL_NET_PLUGIN=none
 # Define nccl version we will test
 # See https://github.com/coreweave/nccl-tests/pkgs/container/nccl-tests for available tags.
 
-nccl_version="13.2.1-devel-ubuntu24.04-nccl2.31.2-1-ee0d4d1"
+nccl_version="13.2.1-devel-ubuntu24.04-nccl2.31.2-1-478d8e5"
 
 # Create a directory to store container images. You can change this
 # or use an existing directory below.

--- a/slurm/nccl-test-distributed-gb200-nvl72-enroot.slurm
+++ b/slurm/nccl-test-distributed-gb200-nvl72-enroot.slurm
@@ -42,7 +42,7 @@ export NCCL_NET_PLUGIN=none
 # Define nccl version we will test
 # See https://github.com/coreweave/nccl-tests/pkgs/container/nccl-tests for available tags.
 
-nccl_version="13.2.1-devel-ubuntu24.04-nccl2.31.2-1-ee0d4d1"
+nccl_version="13.2.1-devel-ubuntu24.04-nccl2.31.2-1-478d8e5"
 
 # Create a directory to store container images. You can change this
 # or use an existing directory below.

--- a/slurm/nccl-test-distributed-gb300-nvl72-enroot.slurm
+++ b/slurm/nccl-test-distributed-gb300-nvl72-enroot.slurm
@@ -44,7 +44,7 @@ export NCCL_NET_PLUGIN=none
 # Define nccl version we will test
 # See https://github.com/coreweave/nccl-tests/pkgs/container/nccl-tests for available tags.
 
-nccl_version="13.2.1-devel-ubuntu24.04-nccl2.31.2-1-ee0d4d1"
+nccl_version="13.2.1-devel-ubuntu24.04-nccl2.31.2-1-478d8e5"
 
 # Create a directory to store container images. You can change this
 # or use an existing directory below.

--- a/slurm/nccl-test-distributed-gb300-roce-nvl72-enroot.slurm
+++ b/slurm/nccl-test-distributed-gb300-roce-nvl72-enroot.slurm
@@ -19,7 +19,6 @@
 # Spectrum-X NCCL plugin
 # https://docs.nvidia.com/networking/display/hpcvx225/spectrum-x-nccl-plugin
 # "spcx" enables the Spectrum-X NCCL plugin on RoCE; set to "none" to disable it.
-export LD_LIBRARY_PATH=/opt/hpcx/nccl_spectrum-x_plugin/lib:$LD_LIBRARY_PATH
 export NCCL_NET_PLUGIN=spcx
 
 # RoCE / Spectrum-X tuning
@@ -49,7 +48,7 @@ export PMIX_MCA_gds='^ds12'
 # Define nccl version we will test
 # See https://github.com/coreweave/nccl-tests/pkgs/container/nccl-tests for available tags.
 
-nccl_version="13.2.1-devel-ubuntu24.04-nccl2.31.2-1-ee0d4d1"
+nccl_version="13.2.1-devel-ubuntu24.04-nccl2.31.2-1-478d8e5"
 
 # Create a directory to store container images. You can change this
 # or use an existing directory below.

--- a/slurm/nccl-test-distributed-h100-64-enroot-sharp.slurm
+++ b/slurm/nccl-test-distributed-h100-64-enroot-sharp.slurm
@@ -34,7 +34,7 @@ export PMIX_MCA_gds='^ds12'
 # Define nccl version we will test
 # See https://github.com/coreweave/nccl-tests/pkgs/container/nccl-tests for available tags.
 
-nccl_version="13.2.1-devel-ubuntu24.04-nccl2.31.2-1-ee0d4d1"
+nccl_version="13.2.1-devel-ubuntu24.04-nccl2.31.2-1-478d8e5"
 
 # Create a directory to store container images. You can change this
 # or use an existing directory below.

--- a/slurm/nccl-test-distributed-h100-64-enroot.slurm
+++ b/slurm/nccl-test-distributed-h100-64-enroot.slurm
@@ -31,7 +31,7 @@ export NCCL_NET_PLUGIN=none
 # Define nccl version we will test
 # See https://github.com/coreweave/nccl-tests/pkgs/container/nccl-tests for available tags.
 
-nccl_version="13.2.1-devel-ubuntu24.04-nccl2.31.2-1-ee0d4d1"
+nccl_version="13.2.1-devel-ubuntu24.04-nccl2.31.2-1-478d8e5"
 
 # Create a directory to store container images. You can change this
 # or use an existing directory below.


### PR DESCRIPTION
# Prefer the NCCL Spectrum-X plugins by default

This change updates the `ENV` directives built into each `nccl-tests` container image to match the current environment given by `/opt/hpcx/hpcx-init.sh`. Notably, this adds the path to the NCCL Spectrum-X net plugin `/opt/hpcx/nccl_spectrum-x_plugin/lib` as the first entry of `LD_LIBRARY_PATH`, meaning that that becomes the default `libnccl-net.so`.

- Any workload that does not set `NCCL_NET_PLUGIN` now gets the equivalent of the old `NCCL_NET_PLUGIN=spcx`,
- `NCCL_NET_PLUGIN=spcx` and the default version of it in general no longer require an extra `LD_LIBRARY_PATH=/opt/hpcx/nccl_spectrum-x_plugin/lib:$LD_LIBRARY_PATH` incantation to support it, and
- `NCCL_NET_PLUGIN=ibext` will switch back to the old default plugin from `/opt/hpcx/nccl_rdma_sharp_plugin/lib`.

## ClusterKit

The latest versions of HPC-X now include ClusterKit on `aarch64`, so that is restored along with the default `PATH` on that architecture.

## Centennial

Happy PR #100! :D